### PR TITLE
UnitTesting: test on MSYS2 (MINGW4)

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -19,6 +19,13 @@ jobs:
     with:
       jobs: ${{ needs.Params.outputs.python_jobs }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}
+      pacboy: >-
+        python-pip:p
+        python-wheel:p
+        python-coverage:p
+        python-lxml:p
+        python-ruamel-yaml:p
+        python-ruamel.yaml.clib:p
 
   Coverage:
     uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@r0

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -127,11 +127,19 @@ jobs:
     with:
       package: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
       remaining: |
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.6
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.7
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.8
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.9
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.7
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.7
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-msys2-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.7
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.10
         ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
         ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
         ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ DescribePythonPackageHostedOnGitHub(
 	description="pyTooling is a powerful collection of arbitrary useful classes, decorators, meta-classes and exceptions.",
 	gitHubNamespace=gitHubNamespace,
 	unittestRequirementsFile=Path("tests/requirements.txt"),
-	additionalRequirements={"yaml": ["ruamel.yaml>=0.17.20"]},
+	additionalRequirements={"yaml": ["ruamel.yaml>=0.17"]},
 	sourceFileWithVersion=packageInformationFile,
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,7 +9,7 @@ pytest-cov>=3.0.0
 
 # Static Type Checking
 mypy>=0.931
-lxml>=4.6.4
+lxml>=4.6
 
 # For pyTooling.Configuration.YAML testing
-ruamel.yaml>=0.17.20
+ruamel.yaml>=0.17


### PR DESCRIPTION
# Changes

* Downgrade lxml and ruaml.yaml, to be compatible with MSYS2's packaged versions.
* UnitTesting: use option pacboy to override the packages installed through pacman.
* ArtifactCleanup: update list of unittesting artifacts.

---

This PR is blocked by pyTooling/Actions#37.