### PR TITLE
New metaclass SuperType

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,13 +48,13 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
 	"_build",
-	"_themes",
+	"_theme",
 	"Thumbs.db",
 	".DS_Store"
 ]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'stata-dark'
+pygments_style = "manni"
 
 
 # ==============================================================================
@@ -105,8 +105,6 @@ htmlhelp_basename = 'pyToolingDoc'
 # The empty string is equivalent to '%b %d, %Y'.
 html_last_updated_fmt = "%d.%m.%Y"
 
-
-pygments_style = "manni"
 
 # ==============================================================================
 # Options for LaTeX / PDF output

--- a/pyTooling/CallByRef/__init__.py
+++ b/pyTooling/CallByRef/__init__.py
@@ -41,7 +41,7 @@ T = TypeVar("T")
 
 
 @export
-class CallByRefParam(Generic[T], metaclass=SuperType):
+class CallByRefParam(Generic[T], metaclass=SuperType, useSlots=True):
 	"""
 	Implements a *call-by-reference* parameter.
 

--- a/pyTooling/CallByRef/__init__.py
+++ b/pyTooling/CallByRef/__init__.py
@@ -35,13 +35,13 @@
 from typing import Any, Generic, TypeVar
 
 from ..Decorators import export
-from ..MetaClasses import SlottedType
+from ..MetaClasses import SuperType
 
 T = TypeVar("T")
 
 
 @export
-class CallByRefParam(Generic[T], metaclass=SlottedType):
+class CallByRefParam(Generic[T], metaclass=SuperType):
 	"""
 	Implements a *call-by-reference* parameter.
 

--- a/pyTooling/Common/Platform.py
+++ b/pyTooling/Common/Platform.py
@@ -35,11 +35,11 @@
 from enum import Flag, auto
 
 from pyTooling.Decorators import export
-from pyTooling.MetaClasses import Singleton
+from pyTooling.MetaClasses import SuperType
 
 
 @export
-class Platform(metaclass=Singleton):
+class Platform(metaclass=SuperType, singleton=True):
 	"""An instance of this class contains all gathered information available from various sources.
 
 	.. seealso::

--- a/pyTooling/Configuration/YAML.py
+++ b/pyTooling/Configuration/YAML.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import Dict, List, Union, Iterator as typing_Iterator
 
 from ..Decorators import export
-from ..MetaClasses import SlottedType
+from ..MetaClasses import SuperType
 
 try:
 	from ruamel.yaml import YAML, CommentedMap, CommentedSeq
@@ -194,7 +194,7 @@ class Dictionary(Abstract_Dict, Node):
 		return key in self._keys
 
 	def __iter__(self) -> typing_Iterator[ValueT]:
-		class Iterator(metaclass=SlottedType):
+		class Iterator(metaclass=SuperType):
 			_iter: typing_Iterator
 			_obj: Dictionary
 
@@ -235,7 +235,7 @@ class Sequence(Abstract_Seq, Node):
 
 		:returns: Iterator to iterate items in a sequence.
 		"""
-		class Iterator(metaclass=SlottedType):
+		class Iterator(metaclass=SuperType):
 			"""Iterator to iterate sequence items."""
 
 			_i: int         #: internal iterator position

--- a/pyTooling/Configuration/YAML.py
+++ b/pyTooling/Configuration/YAML.py
@@ -194,7 +194,7 @@ class Dictionary(Abstract_Dict, Node):
 		return key in self._keys
 
 	def __iter__(self) -> typing_Iterator[ValueT]:
-		class Iterator(metaclass=SuperType):
+		class Iterator(metaclass=SuperType, useSlots=True):
 			_iter: typing_Iterator
 			_obj: Dictionary
 
@@ -235,7 +235,7 @@ class Sequence(Abstract_Seq, Node):
 
 		:returns: Iterator to iterate items in a sequence.
 		"""
-		class Iterator(metaclass=SuperType):
+		class Iterator(metaclass=SuperType, useSlots=True):
 			"""Iterator to iterate sequence items."""
 
 			_i: int         #: internal iterator position

--- a/pyTooling/Configuration/__init__.py
+++ b/pyTooling/Configuration/__init__.py
@@ -44,7 +44,7 @@ ValueT = Union[NodeT, str, int, float]
 
 
 @export
-class Node(metaclass=SuperType):
+class Node(metaclass=SuperType, useSlots=True):
 	"""Abstract node in a configuration data structure."""
 
 	DICT_TYPE: ClassVar["Dictionary"]

--- a/pyTooling/Configuration/__init__.py
+++ b/pyTooling/Configuration/__init__.py
@@ -35,7 +35,7 @@
 from typing import Union, ClassVar, Iterator
 
 from ..Decorators import export
-from ..MetaClasses import SlottedType
+from ..MetaClasses import SuperType
 
 
 KeyT = Union[str, int]
@@ -44,7 +44,7 @@ ValueT = Union[NodeT, str, int, float]
 
 
 @export
-class Node(metaclass=SlottedType):
+class Node(metaclass=SuperType):
 	"""Abstract node in a configuration data structure."""
 
 	DICT_TYPE: ClassVar["Dictionary"]

--- a/pyTooling/Decorators/__init__.py
+++ b/pyTooling/Decorators/__init__.py
@@ -162,12 +162,7 @@ def OriginalFunction(func: FunctionType) -> Callable[[Func], Func]:
 		if not isinstance(f, Callable):
 			raise TypeError(f"Decorated object is not callable.")
 
-		# WORKAROUND:
-		#   Python version: 3.7, 3.8
-		#   Problem:        f.__orig_func__ doesn't work
-		setattr(f, "__orig_func__", func)
-		_ = f.__orig_func__
-#		f.__orig_func__ = func
+		f.__orig_func__ = func
 		return f
 
 	return decorator

--- a/pyTooling/Decorators/__init__.py
+++ b/pyTooling/Decorators/__init__.py
@@ -84,11 +84,11 @@ def export(entity: T) -> T:
 	      assert "exported" in globals()
 	      assert "not_exported" not in globals()
 
-	:param entity:     The function or class to include in `__all__`.
-	:returns:          The unmodified function or class.
-	:raises TypeError: If parameter ``entity`` has no ``__module__`` member.
-	:raises TypeError: If parameter ``entity`` is not a top-level entity in a module.
-	:raises TypeError: If parameter ``entity`` has no ``__name__``.
+	:param entity:          The function or class to include in `__all__`.
+	:returns:               The unmodified function or class.
+	:raises AttributeError: If parameter ``entity`` has no ``__module__`` member.
+	:raises TypeError:      If parameter ``entity`` is not a top-level entity in a module.
+	:raises TypeError:      If parameter ``entity`` has no ``__name__``.
 	"""
 	# * Based on an idea by Duncan Booth:
 	#	  http://groups.google.com/group/comp.lang.python/msg/11cbb03e09611b8a
@@ -96,14 +96,14 @@ def export(entity: T) -> T:
 	#	  http://groups.google.com/group/comp.lang.python/msg/3d400fb22d8a42e1
 
 	if not hasattr(entity, "__module__"):
-		raise TypeError(f"{entity} has no __module__ attribute. Please ensure it is a top-level function or class reference defined in a module.")
+		raise AttributeError(f"{entity} has no __module__ attribute. Please ensure it is a top-level function or class reference defined in a module.")
 
 	if hasattr(entity, "__qualname__"):
 		if any(i in entity.__qualname__ for i in (".", "<locals>", "<lambda>")):
 			raise TypeError(f"Only named top-level functions and classes may be exported, not {entity}")
 
 	if not hasattr(entity, "__name__") or entity.__name__ == "<lambda>":
-		raise TypeError(f"Entity must be a named top-level funcion or class, not {entity.__class__}")
+		raise TypeError(f"Entity must be a named top-level function or class, not {entity.__class__}")
 
 	try:
 		module = sys.modules[entity.__module__]

--- a/pyTooling/Decorators/__init__.py
+++ b/pyTooling/Decorators/__init__.py
@@ -43,13 +43,14 @@ __all__ = ["export", "Param", "RetType", "Func", "T"]
 try:
 	# See https://stackoverflow.com/questions/47060133/python-3-type-hinting-for-decorator
 	from typing import ParamSpec    # exists since Python 3.10
-	Param = ParamSpec("Param")
-	RetType = TypeVar("RetType")
-	Func = Callable[Param, RetType]
+
+	Param = ParamSpec("Param")                       #: A parameter specification for function or method
+	RetType = TypeVar("RetType")                     #: Type variable for a return type
+	Func = Callable[Param, RetType]                  #: Type specification for a function
 except ImportError:
-	Param = ...
-	RetType = TypeVar("RetType")
-	Func = Callable[..., RetType]
+	Param = ...                                      #: A parameter specification for function or method
+	RetType = TypeVar("RetType")                     #: Type variable for a return type
+	Func = Callable[..., RetType]                    #: Type specification for a function
 
 
 T = TypeVar("T", bound=Union[Type, FunctionType])  #: Type variable for a class or function

--- a/pyTooling/Decorators/__init__.py
+++ b/pyTooling/Decorators/__init__.py
@@ -37,11 +37,22 @@ from types     import FunctionType, MethodType
 from typing    import Union, Type, TypeVar, Callable
 
 
-__all__ = ["export", "T", "M", "Param", "RetType", "Func"]
+__all__ = ["export", "Param", "RetType", "Func", "T"]
+
+
+try:
+	# See https://stackoverflow.com/questions/47060133/python-3-type-hinting-for-decorator
+	from typing import ParamSpec    # exists since Python 3.10
+	Param = ParamSpec("Param")
+	RetType = TypeVar("RetType")
+	Func = Callable[Param, RetType]
+except ImportError:
+	Param = ...
+	RetType = TypeVar("RetType")
+	Func = Callable[..., RetType]
 
 
 T = TypeVar("T", bound=Union[Type, FunctionType])  #: Type variable for a class or function
-M = TypeVar("M", bound=MethodType)                 #: Type variable for methods.
 
 
 def export(entity: T) -> T:
@@ -107,16 +118,13 @@ def export(entity: T) -> T:
 	return entity
 
 
-try:
-	# See https://stackoverflow.com/questions/47060133/python-3-type-hinting-for-decorator
-	from typing import ParamSpec    # exists since Python 3.10
-	Param = ParamSpec("Param")
-	RetType = TypeVar("RetType")
-	Func = Callable[Param, RetType]
-except ImportError:
-	Param = ...
-	RetType = TypeVar("RetType")
-	Func = Callable[..., RetType]
+@export
+def OriginalFunction(func: FunctionType) -> Callable[[Func], Func]:
+	def decorator(f: Func) -> Func:
+		f.__orig_func__ = func
+		return f
+
+	return decorator
 
 
 @export

--- a/pyTooling/Decorators/__init__.py
+++ b/pyTooling/Decorators/__init__.py
@@ -162,7 +162,12 @@ def OriginalFunction(func: FunctionType) -> Callable[[Func], Func]:
 		if not isinstance(f, Callable):
 			raise TypeError(f"Decorated object is not callable.")
 
-		f.__orig_func__ = func
+		# WORKAROUND:
+		#   Python version: 3.7, 3.8
+		#   Problem:        f.__orig_func__ doesn't work
+		setattr(f, "__orig_func__", func)
+		_ = f.__orig_func__
+#		f.__orig_func__ = func
 		return f
 
 	return decorator

--- a/pyTooling/Decorators/__init__.py
+++ b/pyTooling/Decorators/__init__.py
@@ -121,7 +121,47 @@ def export(entity: T) -> T:
 
 @export
 def OriginalFunction(func: FunctionType) -> Callable[[Func], Func]:
+	"""Store a reference to the original function/method on a new, wrapper or replacement function/method.
+
+	The function or method reference is stored in ``__orig_func__``.
+
+	.. admonition:: ``metaclass.py``
+
+	   .. code:: python
+
+	      from functools import wraps
+	      from pyTooling.Decorators import OriginalFunction
+
+	      class Meta(type):
+	        def __new__(self, className: str, baseClasses: Tuple[type], members: Dict[str, Any]) -> type:
+	          # Create a new class
+	          newClass = type.__new__(self, className, baseClasses, members)
+
+	          @OriginalFunction(newClass.__new__)
+	          @wraps(newClass.__new__)
+	          def new(cls, *args, **kwargs):
+	            # ...
+	            obj = newClass.__new__(*args, **kwargs)
+	            # ...
+	            return obj
+
+	          newClass.__new__ = new
+
+	          return newClass
+
+	:param func: Function or method reference to be store on the decorated function or method.
+	:returns:    Decorator function that stores the function or method reference on the decorated object.
+	"""
 	def decorator(f: Func) -> Func:
+		"""Decorator function, which stores a reference to a function or method in a new field called ``__orig_func__``.
+
+		:param f:          Function or method, where the original function or method reference is attached to.
+		:returns:          Same method, but with new field ``__orig_func__`` set to the original function or method.
+		:raises TypeError: If decorated object is not callable.
+		"""
+		if not isinstance(f, Callable):
+			raise TypeError(f"Decorated object is not callable.")
+
 		f.__orig_func__ = func
 		return f
 
@@ -131,6 +171,21 @@ def OriginalFunction(func: FunctionType) -> Callable[[Func], Func]:
 @export
 def InheritDocString(baseClass: type) -> Callable[[Func], Func]:
 	"""Copy the doc-string from given base-class to the method this decorator is applied to.
+
+	.. admonition:: ``example.py``
+
+	    .. code:: python
+
+	      from pyTooling.Decorators import InheritDocString
+
+	      class Class1:
+	        def method(self):
+	          '''Method's doc-string.'''
+
+	      class Class2(Class1):
+	        @InheritDocString(Class1)
+	        def method(self):
+	          super().method()
 
 	:param baseClass: Base-class to copy the doc-string from to the new method being decorated.
 	:returns:         Decorator function that copies the doc-string.

--- a/pyTooling/Exceptions/__init__.py
+++ b/pyTooling/Exceptions/__init__.py
@@ -38,7 +38,29 @@ from ..Decorators import export
 
 @export
 class AbstractClassError(Exception):
-	"""The exception ``AbstractClassError`` is raised, when a class contains *abstract* or *must-override* marked methods.
+	"""The exception is raised, when a class contains methods marked with *abstractmethod* or *mustoverride*.
+
+	.. seealso::
+	   :py:func:`@abstractmethod <pyTooling.MetaClasses.abstractmethod>`
+	      |rarr| Mark a method as *abstract*.
+	   :py:func:`@mustoverride <pyTooling.MetaClasses.mustoverride>`
+	      |rarr| Mark a method as *must overrride*.
+	   :py:exc:`~MustOverrideClassError`
+	      |rarr| Exception raised, if a method is marked as *must-override*.
+	"""
+
+
+@export
+class MustOverrideClassError(AbstractClassError):
+	"""The exception is raised, when a class contains methods marked with *must-override*.
+
+	.. seealso::
+	   :py:func:`@abstractmethod <pyTooling.MetaClasses.abstractmethod>`
+	      |rarr| Mark a method as *abstract*.
+	   :py:func:`@mustoverride <pyTooling.MetaClasses.mustoverride>`
+	      |rarr| Mark a method as *must overrride*.
+	   :py:exc:`~AbstractClassError`
+	      |rarr| Exception raised, if a method is marked as *abstract*.
 	"""
 
 
@@ -67,14 +89,14 @@ class ExceptionBase(Exception):
 
 @export
 class EnvironmentException(ExceptionBase):
-	"""``EnvironmentException`` is raised when an expected environment variable is missing."""
+	"""The exception is raised when an expected environment variable is missing."""
 
 
 @export
 class PlatformNotSupportedException(ExceptionBase):
-	"""``PlatformNotSupportedException`` is raise if the platform is not supported."""
+	"""The exception is raise if the platform is not supported."""
 
 
 @export
 class NotConfiguredException(ExceptionBase):
-	"""``NotConfiguredException`` is raise if the requested setting is not configured."""
+	"""The exception is raise if the requested setting is not configured."""

--- a/pyTooling/Exceptions/__init__.py
+++ b/pyTooling/Exceptions/__init__.py
@@ -37,25 +37,26 @@ from ..Decorators import export
 
 
 @export
+class AbstractClassError(Exception):
+	"""The exception ``AbstractClassError`` is raised, when a class contains *abstract* or *must-override* marked methods.
+	"""
+
+
 class ExceptionBase(Exception):
 	"""Base exception derived from :py:exc:`Exception <python:Exception>` for all custom exceptions."""
 
-#	@DocumentMemberAttribute()
 	def __init__(self, message: str = ""):
-		"""
-		pyExceptions initializer.
+		"""pyExceptions initializer.
 
 		:param message:   The exception message.
 		"""
 		super().__init__()
 		self.message = message
 
-#	@DocumentMemberAttribute()
 	def __str__(self) -> str:
 		"""Returns the exception's message text."""
 		return self.message
 
-#	@DocumentMemberAttribute(False)
 	def with_traceback(self, tb) -> None:
 		super().with_traceback(tb)
 

--- a/pyTooling/Exceptions/__init__.py
+++ b/pyTooling/Exceptions/__init__.py
@@ -64,6 +64,17 @@ class MustOverrideClassError(AbstractClassError):
 	"""
 
 
+@export
+class OverloadResolutionError(Exception):
+	"""The exception is raised, when no matching overloaded method was found.
+
+	.. seealso::
+	   :py:func:`@overloadable <pyTooling.MetaClasses.overloadable>`
+	      |rarr| Mark a method as *overloadable*.
+	"""
+
+
+@export
 class ExceptionBase(Exception):
 	"""Base exception derived from :py:exc:`Exception <python:Exception>` for all custom exceptions."""
 

--- a/pyTooling/Exceptions/__init__.py
+++ b/pyTooling/Exceptions/__init__.py
@@ -33,7 +33,16 @@
 
 .. hint:: See :ref:`high-level help <EXECPTION>` for explanations and usage examples.
 """
-from ..Decorators import export
+try:
+	from ..Decorators import export
+except (ImportError, ModuleNotFoundError):
+	print("[pyTooling.MetaClasses] Could not import from 'pyTooling.*'!")
+
+	try:
+		from Decorators import export
+	except (ImportError, ModuleNotFoundError) as ex:
+		print("[pyTooling.MetaClasses] Could not import from 'Decorators' directly!")
+		raise ex
 
 
 @export

--- a/pyTooling/Licensing/__init__.py
+++ b/pyTooling/Licensing/__init__.py
@@ -74,7 +74,7 @@ __all__ = [
 
 @export
 @dataclass
-class PythonLicenseNames(metaclass=SuperType):
+class PythonLicenseNames:
 	"""A *data class* to represent the license's short name and the package classifier for a license."""
 	ShortName: str    #: License's short name
 	Classifier: str   #: Package classifier for a license.
@@ -97,7 +97,7 @@ PYTHON_LICENSE_NAMES: Dict[str, PythonLicenseNames] = {
 
 
 @export
-class License(metaclass=SuperType):
+class License(metaclass=SuperType, useSlots=True):
 	"""Representation of a license."""
 
 	_spdxIdentifier: str  #: Unique SPDX identifier.

--- a/pyTooling/Licensing/__init__.py
+++ b/pyTooling/Licensing/__init__.py
@@ -54,7 +54,7 @@ except (ImportError, ModuleNotFoundError):
 
 	try:
 		from Decorators import export
-		from MetaClasses import SlottedType
+		from MetaClasses import SuperType
 	except (ImportError, ModuleNotFoundError) as ex:
 		print("[pyTooling.Licensing] Could not import from 'Decorators' directly!")
 		raise ex

--- a/pyTooling/Licensing/__init__.py
+++ b/pyTooling/Licensing/__init__.py
@@ -48,7 +48,7 @@ from typing       import Any, Dict
 
 try:
 	from ..Decorators import export
-	from ..MetaClasses import SlottedType
+	from ..MetaClasses import SuperType
 except (ImportError, ModuleNotFoundError):
 	print("[pyTooling.Licensing] Could not import from 'pyTooling.*'!")
 
@@ -74,7 +74,7 @@ __all__ = [
 
 @export
 @dataclass
-class PythonLicenseNames(metaclass=SlottedType):
+class PythonLicenseNames(metaclass=SuperType):
 	"""A *data class* to represent the license's short name and the package classifier for a license."""
 	ShortName: str    #: License's short name
 	Classifier: str   #: Package classifier for a license.
@@ -97,7 +97,7 @@ PYTHON_LICENSE_NAMES: Dict[str, PythonLicenseNames] = {
 
 
 @export
-class License(metaclass=SlottedType):
+class License(metaclass=SuperType):
 	"""Representation of a license."""
 
 	_spdxIdentifier: str  #: Unique SPDX identifier.

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -183,6 +183,17 @@ class SuperType(type):
 		singleton: bool = False,
 		useSlots: bool = False
 	) -> type:
+		"""
+
+		:param className:
+		:param baseClasses:
+		:param members:
+		:param singleton:
+		:param useSlots:
+		:raises AttributeError: If base-class has no '__slots__' attribute.
+		:raises AttributeError: If slot already exists in base-class.
+		"""
+
 		# Check if members should be stored in slots. If so get these members from type annotated fields
 		if useSlots:
 			members['__slots__'] = self.__getSlots(baseClasses, members)
@@ -282,7 +293,7 @@ class SuperType(type):
 		for baseClass in baseClasses:
 			for base in reversed(baseClass.mro()[:-1]):
 				if not hasattr(base, "__slots__"):
-					raise TypeError(f"Base-class '{base.__name__}' has no '__slots__'.")
+					raise AttributeError(f"Base-class '{base.__name__}' has no '__slots__'.")
 
 				for annotation in base.__slots__:
 					annotatedFields[annotation] = base
@@ -292,6 +303,6 @@ class SuperType(type):
 		annotations: Dict[str, Any] = members.get("__annotations__", {})
 		for annotation in annotations:
 			if annotation in annotatedFields:
-				raise TypeError(f"Slot '{annotation}' already exists in base-class '{annotatedFields[annotation]}'.")
+				raise AttributeError(f"Slot '{annotation}' already exists in base-class '{annotatedFields[annotation]}'.")
 
 		return (*members.get('__slots__', []), *annotations)

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -283,7 +283,11 @@ class SuperType(type):
 			# skip intermediate 'new' function if class isn't abstract anymore
 			# if '__new__' is identical to the one from object, it was never wrapped -> no action needed
 			if newClass.__new__ is not object.__new__:
-				newClass.__new__ = newClass.__new__.__orig_func__
+				try:
+					newClass.__new__ = newClass.__new__.__orig_func__
+				except AttributeError:
+					print(f"AttributeError for newClass.__new__.__orig_func__ caused by '{newClass.__new__.__name__}'")
+					pass
 
 			return False
 

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -251,6 +251,8 @@ class SuperType(type):
 						oldinit(self, *args, **kwargs)
 						cls.__singletonInstanceInit__ = False
 						cv.notify_all()
+					elif args or kwargs:
+						raise ValueError(f"A further instance of a singleton can't be reinitialized with parameters.")
 					else:
 						while cls.__singletonInstanceInit__:
 							cv.wait()

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -295,11 +295,11 @@ class SuperType(type):
 				# WORKAROUND:
 				#   Python version: 3.7, 3.8
 				#   Problem:        __orig_func__ doesn't exist, if __new__ is not from object
-				try:
-					newClass.__new__ = newClass.__new__.__orig_func__
-				except AttributeError:
-					print(f"AttributeError for newClass.__new__.__orig_func__ caused by '{newClass.__new__.__name__}'")
-					pass
+				#try:
+				newClass.__new__ = newClass.__new__.__orig_func__
+				#except AttributeError:
+				#	print(f"AttributeError for newClass.__new__.__orig_func__ caused by '{newClass.__new__.__name__}'")
+				#	pass
 
 			return False
 

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -289,7 +289,6 @@ class SuperType(type):
 					newClass.__new__ = newClass.__new__.__orig_func__
 				except AttributeError:
 					print(f"AttributeError for newClass.__new__.__orig_func__ caused by '{newClass.__new__.__name__}'")
-					pass
 
 			return False
 

--- a/pyTooling/Packaging/__init__.py
+++ b/pyTooling/Packaging/__init__.py
@@ -52,7 +52,7 @@ except (ImportError, ModuleNotFoundError):
 
 	try:
 		from Decorators import export
-		from MetaClasses import SlottedType
+		from MetaClasses import SuperType
 		from Licensing import License, Apache_2_0_License
 	except (ImportError, ModuleNotFoundError) as ex:
 		print("[pyTooling.Packaging] Could not import from 'Decorators', 'MetaClasses' or 'Licensing' directly!")
@@ -130,7 +130,7 @@ def loadRequirementsFile(requirementsFile: Path, indent: int = 0, debug: bool = 
 
 
 @export
-class VersionInformation(metaclass=SuperType):
+class VersionInformation(metaclass=SuperType, useSlots=True):
 	"""Encapsulates version information extracted from a Python source file."""
 
 	_author: str          #: Author name(s).

--- a/pyTooling/Packaging/__init__.py
+++ b/pyTooling/Packaging/__init__.py
@@ -230,9 +230,9 @@ def extractVersionInformation(sourceFile: Path) -> VersionInformation:
 							if isinstance(const, Constant) and isinstance(const.value, str):
 								_keywords.append(const.value)
 							else:
-								raise TypeError
+								raise TypeError  # TODO: add error message
 					else:
-						raise TypeError
+						raise TypeError  # TODO: add error message
 				if isinstance(target, Name) and target.id == "__license__" and isinstance(value, Constant) and isinstance(value.value, str):
 					_license = value.value
 				if isinstance(target, Name) and target.id == "__version__" and isinstance(value, Constant) and isinstance(value.value, str):

--- a/pyTooling/Packaging/__init__.py
+++ b/pyTooling/Packaging/__init__.py
@@ -45,7 +45,7 @@ from typing       import List, Iterable, Dict, Sequence
 
 try:
 	from ..Decorators import export
-	from ..MetaClasses import SlottedType
+	from ..MetaClasses import SuperType
 	from ..Licensing  import License, Apache_2_0_License
 except (ImportError, ModuleNotFoundError):
 	print("[pyTooling.Packaging] Could not import from 'pyTooling.*'!")
@@ -130,7 +130,7 @@ def loadRequirementsFile(requirementsFile: Path, indent: int = 0, debug: bool = 
 
 
 @export
-class VersionInformation(metaclass=SlottedType):
+class VersionInformation(metaclass=SuperType):
 	"""Encapsulates version information extracted from a Python source file."""
 
 	_author: str          #: Author name(s).

--- a/pyTooling/Tree/__init__.py
+++ b/pyTooling/Tree/__init__.py
@@ -43,7 +43,7 @@ DictValueT = TypeVar("DictValueT")
 
 
 @export
-class Node(Generic[IDT, ValueT, DictKeyT, DictValueT], metaclass=SuperType):
+class Node(Generic[IDT, ValueT, DictKeyT, DictValueT], metaclass=SuperType, useSlots=True):
 	"""A **tree** data structure can be constructed of ``Node`` instances.
 
 	Therefore, nodes can be connected to parent nodes or a parent node can add child nodes. This allows to construct a

--- a/pyTooling/Tree/__init__.py
+++ b/pyTooling/Tree/__init__.py
@@ -34,7 +34,7 @@ from typing import List, Generator, Iterable, TypeVar, Generic, Dict, Optional a
 	Union, Deque
 
 from ..Decorators import export
-from ..MetaClasses import SlottedType
+from ..MetaClasses import SuperType
 
 IDT = TypeVar("IDT", bound=Hashable)
 ValueT = TypeVar("ValueT")
@@ -43,7 +43,7 @@ DictValueT = TypeVar("DictValueT")
 
 
 @export
-class Node(Generic[IDT, ValueT, DictKeyT, DictValueT], metaclass=SlottedType):
+class Node(Generic[IDT, ValueT, DictKeyT, DictValueT], metaclass=SuperType):
 	"""A **tree** data structure can be constructed of ``Node`` instances.
 
 	Therefore, nodes can be connected to parent nodes or a parent node can add child nodes. This allows to construct a

--- a/pyTooling/Versioning/__init__.py
+++ b/pyTooling/Versioning/__init__.py
@@ -45,32 +45,33 @@ class SemVersion(metaclass=Overloading):
 
 	class Parts(IntEnum):
 		"""Enumeration of parts in a version number that can be presents."""
-		Major = 1       #: Major number (e.g. X in ``vX.0.0``).
-		Minor = 2       #: Minor number (e.g. Y in ``v0.Y.0``).
-		Patch = 4       #: Patch number (e.g. Z in ``v0.0.Z``).
-		Build = 8       #: Build number (e.g. bbbb in ``v0.0.0.bbbb``)
-		Pre   = 16      #: Pre-release number
-		Post  = 32      #: Post-release number
-		Prefix = 64     #: Prefix
-		Postfix = 128   #: Postfix
-		AHead   = 256
+		Major = 1       #: Major number is present. (e.g. X in ``vX.0.0``).
+		Minor = 2       #: Minor number is present. (e.g. Y in ``v0.Y.0``).
+		Patch = 4       #: Patch number is present. (e.g. Z in ``v0.0.Z``).
+		Build = 8       #: Build number is present. (e.g. bbbb in ``v0.0.0.bbbb``)
+		Pre   = 16      #: Pre-release number is present.
+		Post  = 32      #: Post-release number is present.
+		Prefix = 64     #: Prefix is present.
+		Postfix = 128   #: Postfix is present.
+#		AHead   = 256
 
 	class Flags(IntEnum):
 		"""State enumeration, if a (tagged) version is build from a clean or dirty working directory."""
 		Clean = 1       #: A versioned build was created from a *clean* working directory.
 		Dirty = 2       #: A versioned build was created from a *dirty* working directory.
 
-	parts   : Parts
-	flags   : int = Flags.Clean
-	major   : int = 0
-	minor   : int = 0
-	patch   : int = 0
-	build   : int = 0
-	pre     : int = 0
-	post    : int = 0
-	prefix  : str = ""
-	postfix : str = ""
-	ahead   : int = 0
+	parts   : Parts                #: Integer flag enumeration of present parts in a version number.
+	flags   : int = Flags.Clean    #: State if the version in a working directory is clean or dirty compared to a tagged version.
+	major   : int = 0              #: Major number part of the version number.
+	minor   : int = 0              #: Minor number part of the version number.
+	patch   : int = 0              #: Patch number part of the version number.
+	build   : int = 0              #: Build number part of the version number.
+	pre     : int = 0              #: Pre-release version number part.
+	post    : int = 0              #: Post-release version number part.
+	prefix  : str = ""             #: Prefix string
+	postfix : str = ""             #: Postfix string
+# QUESTION: was this how many commits a version is ahead of the last tagged version?
+#	ahead   : int = 0
 
 	def __init__(self, versionString : str):
 		if versionString == "":

--- a/pyTooling/Versioning/__init__.py
+++ b/pyTooling/Versioning/__init__.py
@@ -33,7 +33,7 @@
 .. hint:: See :ref:`high-level help <VERSIONING>` for explanations and usage examples.
 """
 from enum          import IntEnum
-from typing import Optional as Nullable, Any
+from typing        import Optional as Nullable, Any
 
 from ..Decorators  import export
 from ..MetaClasses import Overloading
@@ -44,19 +44,21 @@ class SemVersion(metaclass=Overloading):
 	"""Representation of a semantic version number like ``3.7.12``."""
 
 	class Parts(IntEnum):
-		Major = 1
-		Minor = 2
-		Patch = 4
-		Build = 8
-		Pre   = 16
-		Post  = 32
-		Prefix = 64
-		Postfix = 128
+		"""Enumeration of parts in a version number that can be presents."""
+		Major = 1       #: Major number (e.g. X in ``vX.0.0``).
+		Minor = 2       #: Minor number (e.g. Y in ``v0.Y.0``).
+		Patch = 4       #: Patch number (e.g. Z in ``v0.0.Z``).
+		Build = 8       #: Build number (e.g. bbbb in ``v0.0.0.bbbb``)
+		Pre   = 16      #: Pre-release number
+		Post  = 32      #: Post-release number
+		Prefix = 64     #: Prefix
+		Postfix = 128   #: Postfix
 		AHead   = 256
 
 	class Flags(IntEnum):
-		Clean = 1
-		Dirty = 2
+		"""State enumeration, if a (tagged) version is build from a clean or dirty working directory."""
+		Clean = 1       #: A versioned build was created from a *clean* working directory.
+		Dirty = 2       #: A versioned build was created from a *dirty* working directory.
 
 	parts   : Parts
 	flags   : int = Flags.Clean
@@ -101,8 +103,9 @@ class SemVersion(metaclass=Overloading):
 	def __eq__(self, other: Any) -> bool:
 		"""Compare two Version instances (version numbers) for equality.
 
-		:returns: True, if both version numbers are equal.
-		raise TypeError(f"Parameter 'other' is not of type 'SemVersion'.")
+		:param other:      Parameter to compare against.
+		:returns:          True, if both version numbers are equal.
+		:raises TypeError: If parameter ``other`` is not of type :py:class:`SemVersion`.
 		"""
 		if not isinstance(other, SemVersion):
 			raise TypeError(f"Parameter 'other' is not of type 'SemVersion'.")
@@ -117,8 +120,9 @@ class SemVersion(metaclass=Overloading):
 	def __ne__(self, other: Any) -> bool:
 		"""Compare two Version instances (version numbers) for inequality.
 
-		:returns: True, if both version numbers are not equal.
-		raise TypeError(f"Parameter 'other' is not of type 'SemVersion'.")
+		:param other:      Parameter to compare against.
+		:returns:          True, if both version numbers are not equal.
+		:raises TypeError: If parameter ``other`` is not of type :py:class:`SemVersion`.
 		"""
 		if not isinstance(other, SemVersion):
 			raise TypeError(f"Parameter 'other' is not of type 'SemVersion'.")
@@ -127,6 +131,14 @@ class SemVersion(metaclass=Overloading):
 
 	@staticmethod
 	def __compare(left: 'SemVersion', right: 'SemVersion') -> Nullable[bool]:
+		"""Private helper method to compute the comparison of two :py:class:`SemVersion` instances.
+
+		:param left:  Left parameter.
+		:param right: Right parameter.
+		:returns:     True, if ``left`` is smaller than ``right``. |br|
+		              False if ``left`` is greater than ``right``. |br|
+		              Otherwise it's None (both parameters are equal).
+		"""
 		if (left.major < right.major):
 			return True
 		if (left.major > right.major):
@@ -152,7 +164,8 @@ class SemVersion(metaclass=Overloading):
 	def __lt__(self, other: Any) -> bool:
 		"""Compare two Version instances (version numbers) if the version is less than the second operand.
 
-		:returns: True if version is less than the second operand.
+		:param other:      Parameter to compare against.
+		:returns:          True if version is less than the second operand.
 		:raises TypeError: If parameter ``other`` is not of type :py:class:`SemVersion`.
 		"""
 		if not isinstance(other, SemVersion):
@@ -164,7 +177,8 @@ class SemVersion(metaclass=Overloading):
 	def __le__(self, other: Any) -> bool:
 		"""Compare two Version instances (version numbers) if the version is less than or equal to the second operand.
 
-		:returns: True if version is less than or equal to the second operand.
+		:param other:      Parameter to compare against.
+		:returns:          True if version is less than or equal to the second operand.
 		:raises TypeError: If parameter ``other`` is not of type :py:class:`SemVersion`.
 		"""
 		if not isinstance(other, SemVersion):
@@ -176,7 +190,8 @@ class SemVersion(metaclass=Overloading):
 	def __gt__(self, other: Any) -> bool:
 		"""Compare two Version instances (version numbers) if the version is greater than the second operand.
 
-		:returns: True if version is greater than the second operand.
+		:param other:      Parameter to compare against.
+		:returns:          True if version is greater than the second operand.
 		:raises TypeError: If parameter ``other`` is not of type :py:class:`SemVersion`.
 		"""
 		if not isinstance(other, SemVersion):
@@ -187,7 +202,8 @@ class SemVersion(metaclass=Overloading):
 	def __ge__(self, other: Any) -> bool:
 		"""Compare two Version instances (version numbers) if the version is greater than or equal to the second operand.
 
-		:returns: True if version is greater than or equal to the second operand.
+		:param other:      Parameter to compare against.
+		:returns:          True if version is greater than or equal to the second operand.
 		:raises TypeError: If parameter ``other`` is not of type :py:class:`SemVersion`.
 		"""
 		if not isinstance(other, SemVersion):

--- a/tests/benchmark/MetaClasses/SlottedType.py
+++ b/tests/benchmark/MetaClasses/SlottedType.py
@@ -28,10 +28,10 @@
 # SPDX-License-Identifier: Apache-2.0                                                                                  #
 # ==================================================================================================================== #
 #
-"""Performance tests for SlottedType."""
+"""Performance tests for SuperType."""
 from pytest import mark
 
-from pyTooling.MetaClasses import SlottedType
+from pyTooling.MetaClasses import SuperType
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -50,7 +50,7 @@ class Node_1:
 		self._data_0 = self._data_0 + add
 
 
-class SlottedNode_1(metaclass=SlottedType):
+class SlottedNode_1(metaclass=SuperType):
 	_data_0: int
 
 	def __init__(self, data):
@@ -96,7 +96,7 @@ class Node_10:
 		self._data_9 = self._data_8 + add
 
 
-class SlottedNode_10(metaclass=SlottedType):
+class SlottedNode_10(metaclass=SuperType):
 	_data_0: int
 	_data_1: int
 	_data_2: int

--- a/tests/benchmark/MetaClasses/SlottedType.py
+++ b/tests/benchmark/MetaClasses/SlottedType.py
@@ -50,7 +50,7 @@ class Node_1:
 		self._data_0 = self._data_0 + add
 
 
-class SlottedNode_1(metaclass=SuperType):
+class SlottedNode_1(metaclass=SuperType, useSlots=True):
 	_data_0: int
 
 	def __init__(self, data):
@@ -96,7 +96,7 @@ class Node_10:
 		self._data_9 = self._data_8 + add
 
 
-class SlottedNode_10(metaclass=SuperType):
+class SlottedNode_10(metaclass=SuperType, useSlots=True):
 	_data_0: int
 	_data_1: int
 	_data_2: int

--- a/tests/unit/MetaClasses/Abstract.py
+++ b/tests/unit/MetaClasses/Abstract.py
@@ -36,6 +36,7 @@ Unit tests for class :py:class:`pyTooling.MetaClasses.Abstract`.
 """
 from unittest       import TestCase
 
+from pyTooling.Exceptions import AbstractClassError
 from pyTooling.MetaClasses import SuperType, abstractmethod, mustoverride
 
 if __name__ == "__main__": # pragma: no cover
@@ -91,14 +92,14 @@ class Abstract(TestCase):
 		cls = NormalClass()
 
 	def test_AbstractBase(self) -> None:
-		with self.assertRaises(TypeError) as ExceptionCapture:
+		with self.assertRaises(AbstractClassError) as ExceptionCapture:
 			base = AbstractBase()
 
 		self.assertIn("AbstractBase", str(ExceptionCapture.exception))
 		self.assertIn("AbstractMethod", str(ExceptionCapture.exception))
 
 	def test_AbstractClass(self) -> None:
-		with self.assertRaises(TypeError) as ExceptionCapture:
+		with self.assertRaises(AbstractClassError) as ExceptionCapture:
 			base = AbstractClass()
 
 		self.assertIn("AbstractClass", str(ExceptionCapture.exception))
@@ -113,14 +114,14 @@ class Abstract(TestCase):
 		self.assertEqual("Method 'AbstractMethod' is abstract and needs to be overridden in a derived class.", str(ExceptionCapture.exception))
 
 	def test_MustOverrideBase(self) -> None:
-		with self.assertRaises(TypeError) as ExceptionCapture:
+		with self.assertRaises(AbstractClassError) as ExceptionCapture:
 			base = MustOverrideBase()
 
 		self.assertIn("MustOverrideBase", str(ExceptionCapture.exception))
 		self.assertIn("MustOverrideMethod", str(ExceptionCapture.exception))
 
 	def test_MustOverrideClass(self) -> None:
-		with self.assertRaises(TypeError) as ExceptionCapture:
+		with self.assertRaises(AbstractClassError) as ExceptionCapture:
 			base = MustOverrideClass()
 
 		self.assertIn("MustOverrideClass", str(ExceptionCapture.exception))

--- a/tests/unit/MetaClasses/Singleton.py
+++ b/tests/unit/MetaClasses/Singleton.py
@@ -104,6 +104,15 @@ class Singleton(TestCase):
 		self.assertEqual(2, app_1.X)
 		self.assertEqual(12, app_2.X)
 
+	def test_2(self):
+		# ensure at least one instance was created
+		Application1()
+
+		with self.assertRaises(ValueError) as ExceptionCapture:
+			Application1(x = 35)
+
+		self.assertEqual("A further instance of a singleton can't be reinitialized with parameters.", str(ExceptionCapture.exception))
+
 	# def test_2(self):
 	# 	self.assertEqual(Application3.X, 0)
 	#

--- a/tests/unit/MetaClasses/Singleton.py
+++ b/tests/unit/MetaClasses/Singleton.py
@@ -36,7 +36,7 @@ Unit tests for class :py:class:`pyTooling.MetaClasses.Singleton`.
 """
 from unittest       import TestCase
 
-from pyTooling.MetaClasses import Singleton
+from pyTooling.MetaClasses import SuperType
 
 
 if __name__ == "__main__": # pragma: no cover
@@ -45,7 +45,7 @@ if __name__ == "__main__": # pragma: no cover
 	exit(1)
 
 
-class Application1(metaclass=Singleton):
+class Application1(metaclass=SuperType, singleton=True):
 	X = 0
 
 	def __init__(self):
@@ -53,6 +53,14 @@ class Application1(metaclass=Singleton):
 
 		self.X = 1
 
+
+class Application2(metaclass=SuperType, singleton=True):
+	X = 10
+
+	def __init__(self):
+		print("Instance of 'Application2' was created")
+
+		self.X = 11
 
 # class Application2(metaclass=Singleton, includeDerivedVariants=True):
 # 	X = 0
@@ -72,18 +80,29 @@ class Application1(metaclass=Singleton):
 
 class Singleton(TestCase):
 	def test_1(self) -> None:
-		self.assertEqual(Application1.X, 0)
+		self.assertEqual(0, Application1.X)
+		self.assertEqual(10, Application2.X)
 
-		app = Application1()
-		self.assertEqual(app.X, 1)
+		app_1 = Application1()
+		self.assertEqual(1, app_1.X)
 
-		app.X = 2
-		self.assertEqual(app.X, 2)
+		app_1.X = 2
+		self.assertEqual(2, app_1.X)
 
-		app2 = Application1()
-		self.assertEqual(app2.X, 2)
+		app_1same = Application1()
+		self.assertIs(app_1, app_1same)
+		self.assertEqual(2, app_1same.X)
 
-		self.assertEqual(Application1.X, 0)
+		self.assertEqual(0, Application1.X)
+
+		app_2 = Application2()
+		self.assertIsNot(app_1, app_2)
+		self.assertEqual(2, app_1.X)
+		self.assertEqual(11, app_2.X)
+
+		app_2.X = 12
+		self.assertEqual(2, app_1.X)
+		self.assertEqual(12, app_2.X)
 
 	# def test_2(self):
 	# 	self.assertEqual(Application3.X, 0)

--- a/tests/unit/MetaClasses/SlottedType.py
+++ b/tests/unit/MetaClasses/SlottedType.py
@@ -91,7 +91,7 @@ class Slotted(TestCase):
 		class Base:
 			_baseData: int
 
-		with self.assertRaises(TypeError):
+		with self.assertRaises(AttributeError):
 			class SlottedData(Base, metaclass=SuperType, useSlots=True):
 				_data: int
 

--- a/tests/unit/MetaClasses/SlottedType.py
+++ b/tests/unit/MetaClasses/SlottedType.py
@@ -29,7 +29,7 @@
 # ==================================================================================================================== #
 #
 """
-Unit tests for class :metacls:`pyTooling.MetaClasses.SlottedType`.
+Unit tests for class :py:class:`pyTooling.MetaClasses.SuperType`.
 
 :copyright: Copyright 2007-2022 Patrick Lehmann - Bötzingen, Germany
 :license: Apache License, Version 2.0
@@ -37,7 +37,7 @@ Unit tests for class :metacls:`pyTooling.MetaClasses.SlottedType`.
 import sys
 from unittest       import TestCase
 
-from pyTooling.MetaClasses import SlottedType
+from pyTooling.MetaClasses import SuperType
 
 
 if __name__ == "__main__": # pragma: no cover
@@ -58,7 +58,7 @@ class Slotted(TestCase):
 
 
 	def test_SlottedData(self):
-		class SlottedData(metaclass=SlottedType):
+		class SlottedData(metaclass=SuperType, useSlots=True):
 			_data: int
 
 			def __init__(self, data: int):
@@ -86,7 +86,7 @@ class Slotted(TestCase):
 			_baseData: int
 
 		with self.assertRaises(TypeError):
-			class SlottedData(Base, metaclass=SlottedType):
+			class SlottedData(Base, metaclass=SuperType, useSlots=True):
 				_data: int
 
 				def __init__(self, data: int):


### PR DESCRIPTION
# New Features
* Created a new metaclass to combine features from `SlottedType`, `Singleton` and abstract in a single metaclass.
  * Removed `SlottedType` metaclass and moved behavior into `SuperType`.
  * Removed `Singleton` and moved behavior into `SuperType`.
    * Don't use `__call__` anymore, as it creates a 10x slowdown in instance creation.
    * Made Singleton threadsafe (by @skoehler).
  * Merged functionality of ABC abstract into `SuperType`.
* Added decorators:
  * `@OriginalFunction`
  * `@abstractmethod`
  * `@mustoverride`
  * `@overloadable`
* Added new exceptions:
  * `AbstractClassError`
  * `MustOverrideClassError`
  * `OverloadResolutionError`

# Changes
* Improved lots of doc-strings.
* Improved lots of type hints.

# Bug Fixes
* Fixed exclude_pattern in Sphinx configuration.
