### PR TITLE
v2.3.0

### DIFF
--- a/pyTooling/Common/__init__.py
+++ b/pyTooling/Common/__init__.py
@@ -37,7 +37,7 @@ __author__ =    "Patrick Lehmann"
 __email__ =     "Paebbels@gmail.com"
 __copyright__ = "2017-2022, Patrick Lehmann"
 __license__ =   "Apache License, Version 2.0"
-__version__ =   "2.2.0"
+__version__ =   "2.3.0"
 __keywords__ =  ["decorators", "meta classes", "exceptions", "platform", "versioning", "licensing", "overloading", "singleton", "tree", "data structure", "setuptools", "wheel", "installation", "packaging", "path", "generic path", "generic library", "url"]
 
 from collections import deque

--- a/pyTooling/Decorators/__init__.py
+++ b/pyTooling/Decorators/__init__.py
@@ -120,15 +120,17 @@ def export(entity: T) -> T:
 
 
 @export
-def ClassProperty(method):
-	"""A decorator adding properties to classes."""
+def classproperty(method):
 
 	class Descriptor:
+		"""A decorator adding properties to classes."""
 		_getter: Callable
 		_setter: Callable
 
-		def __init__(self, method: Callable = None):
-			self._getter = method
+		def __init__(self, getter: Callable = None, setter: Callable = None):
+			self._getter = getter
+			self._setter = setter
+			self.__doc__ = getter.__doc__
 
 		def __get__(self, instance: Any, owner: type = None) -> Any:
 			return self._getter(owner)
@@ -136,11 +138,11 @@ def ClassProperty(method):
 		def __set__(self, instance: Any, value: Any) -> None:
 			self._setter(instance.__class__, value)
 
-		def setter(self, method: Callable):
-			self._setter = method
-			return self
+		def setter(self, setter: Callable):
+			return self.__class__(self._getter, setter)
 
-	return Descriptor(method)
+	descriptor = Descriptor(method)
+	return descriptor
 
 
 @export

--- a/pyTooling/Decorators/__init__.py
+++ b/pyTooling/Decorators/__init__.py
@@ -33,7 +33,7 @@
 .. hint:: See :ref:`high-level help <DECO>` for explanations and usage examples.
 """
 import sys
-from types     import FunctionType, MethodType
+from types     import FunctionType
 from typing import Union, Type, TypeVar, Callable, Any
 
 __all__ = ["export", "Param", "RetType", "Func", "T"]
@@ -121,6 +121,8 @@ def export(entity: T) -> T:
 
 @export
 def ClassProperty(method):
+	"""A decorator adding properties to classes."""
+
 	class Descriptor:
 		_getter: Callable
 		_setter: Callable

--- a/pyTooling/Tree/__init__.py
+++ b/pyTooling/Tree/__init__.py
@@ -262,6 +262,15 @@ class Node(Generic[IDT, ValueT, DictKeyT, DictValueT], metaclass=ExtendedType, u
 		raise NotImplementedError(f"Property 'Level' is not yet implemented.")
 
 	@property
+	def Size(self) -> int:
+		"""
+		Read-only property to return the size of the tree.
+
+		:return: Count of all nodes in the tree structure.
+		"""
+		return len(self._root._nodesWithID) + len(self._root._nodesWithoutID)
+
+	@property
 	def IsRoot(self) -> bool:
 		"""
 		Returns true, if the node is the root node (representative node of the tree).

--- a/pyTooling/Tree/__init__.py
+++ b/pyTooling/Tree/__init__.py
@@ -31,7 +31,7 @@
 """A powerful tree data structure for Python."""
 from collections import deque
 from typing import List, Generator, Iterable, TypeVar, Generic, Dict, Optional as Nullable, Hashable, Tuple, Callable, \
-	Union, Deque
+	Union, Deque, Iterator
 
 from ..Decorators import export
 from ..MetaClasses import ExtendedType
@@ -572,6 +572,14 @@ class Node(Generic[IDT, ValueT, DictKeyT, DictValueT], metaclass=ExtendedType, u
 
 	def Find(self, predicate: Callable) -> Generator['Node', None, None]:
 		raise NotImplementedError(f"Method 'Find' is not yet implemented.")
+
+	def __iter__(self) -> Iterator['Node']:
+		"""
+		Returns an iterator to iterate all child nodes.
+
+		:return: Children iterator.
+		"""
+		return iter(self._children)
 
 	def __len__(self) -> int:
 		"""

--- a/pyTooling/Tree/__init__.py
+++ b/pyTooling/Tree/__init__.py
@@ -573,6 +573,14 @@ class Node(Generic[IDT, ValueT, DictKeyT, DictValueT], metaclass=ExtendedType, u
 	def Find(self, predicate: Callable) -> Generator['Node', None, None]:
 		raise NotImplementedError(f"Method 'Find' is not yet implemented.")
 
+	def __len__(self) -> int:
+		"""
+		Returns the number of children, but not including grand-children.
+
+		:return: Number of child nodes.
+		"""
+		return len(self._children)
+
 	def __repr__(self) -> str:
 		"""
 		Returns a detailed string representation of the node.

--- a/tests/unit/CallByRef/CallByRef.py
+++ b/tests/unit/CallByRef/CallByRef.py
@@ -74,7 +74,7 @@ class CallByReference_AnyParam(TestCase):
 
 
 class CallByReference_BoolParam(TestCase):
-	ref : CallByRefBoolParam = CallByRefBoolParam()
+	ref: CallByRefBoolParam = CallByRefBoolParam()
 
 	def setUp(self) -> None:
 		func2(self.ref)
@@ -85,8 +85,14 @@ class CallByReference_BoolParam(TestCase):
 	def test_Equal(self) -> None:
 		self.assertTrue(self.ref == True)
 
+		with self.assertRaises(TypeError):
+			self.ref == "str"
+
 	def test_Unequal(self) -> None:
 		self.assertTrue(self.ref != False)
+
+		with self.assertRaises(TypeError):
+			self.ref != "str"
 
 	def test_TypeConvertToBool(self) -> None:
 		self.assertTrue(bool(self.ref))
@@ -96,7 +102,7 @@ class CallByReference_BoolParam(TestCase):
 
 
 class CallByReference_IntParam(TestCase):
-	ref : CallByRefIntParam = CallByRefIntParam()
+	ref: CallByRefIntParam = CallByRefIntParam()
 
 	def test_Value(self) -> None:
 		assign_42(self.ref)
@@ -118,88 +124,193 @@ class CallByReference_IntParam(TestCase):
 		assign_42(self.ref)
 		self.assertTrue(self.ref >= 40)
 
+		with self.assertRaises(TypeError):
+			self.ref >= "str"
+
 	def test_GreaterThan(self) -> None:
 		assign_42(self.ref)
-		self.assertTrue(self.ref >  41)
+		self.assertTrue(self.ref > 41)
+
+		with self.assertRaises(TypeError):
+			self.ref > "str"
 
 	def test_Equal(self) -> None:
 		assign_42(self.ref)
 		self.assertTrue(self.ref == 42)
 
+		with self.assertRaises(TypeError):
+			self.ref == "str"
+
 	def test_Unequal(self) -> None:
 		assign_42(self.ref)
 		self.assertTrue(self.ref != 43)
 
+		with self.assertRaises(TypeError):
+			self.ref != "str"
+
 	def test_LessThan(self) -> None:
 		assign_42(self.ref)
-		self.assertTrue(self.ref <  44)
+		self.assertTrue(self.ref < 44)
+
+		with self.assertRaises(TypeError):
+			self.ref < "str"
 
 	def test_LessThanOrEqual(self) -> None:
 		assign_42(self.ref)
 		self.assertTrue(self.ref <= 45)
 
+		with self.assertRaises(TypeError):
+			self.ref <= "str"
+
 	def test_Addition(self) -> None:
 		assign_42(self.ref)
 		self.assertEqual(self.ref + 1, 43)
+
+		with self.assertRaises(TypeError):
+			self.ref + "str"
 
 	def test_Subtraction(self) -> None:
 		assign_42(self.ref)
 		self.assertEqual(self.ref - 1, 41)
 
+		with self.assertRaises(TypeError):
+			self.ref - "str"
+
 	def test_Multiplication(self) -> None:
 		assign_42(self.ref)
 		self.assertEqual(self.ref * 1, 42)
+
+		with self.assertRaises(TypeError):
+			self.ref * "str"
 
 	def test_Power(self) -> None:
 		assign_42(self.ref)
 		self.assertEqual(self.ref ** 1, 42)
 
+		with self.assertRaises(TypeError):
+			self.ref ** "str"
+
 	def test_Division(self) -> None:
 		assign_42(self.ref)
 		self.assertEqual(self.ref / 1, 42)
+
+		with self.assertRaises(TypeError):
+			self.ref / "str"
 
 	def test_FloorDivision(self) -> None:
 		assign_42(self.ref)
 		self.assertEqual(self.ref // 1, 42)
 
+		with self.assertRaises(TypeError):
+			self.ref // "str"
+
 	def test_Modulo(self) -> None:
 		assign_42(self.ref)
 		self.assertEqual(self.ref % 2, 0)
+
+		with self.assertRaises(TypeError):
+			self.ref % "str"
+
+	def test_And(self) -> None:
+		assign_42(self.ref)
+		self.assertEqual(self.ref & 2, 2)
+
+		with self.assertRaises(TypeError):
+			self.ref & "str"
+
+	def test_Or(self) -> None:
+		assign_42(self.ref)
+		self.assertEqual(self.ref | 1, 43)
+
+		with self.assertRaises(TypeError):
+			self.ref | "str"
+
+	def test_Xor(self) -> None:
+		assign_42(self.ref)
+		self.assertEqual(self.ref ^ 2, 40)
+
+		with self.assertRaises(TypeError):
+			self.ref ^ "str"
 
 	def test_Increment(self) -> None:
 		assign_42(self.ref)
 		self.ref += 1
 		self.assertEqual(self.ref, 43)
 
+		with self.assertRaises(TypeError):
+			self.ref += "str"
+
 	def test_Decrement(self) -> None:
 		assign_42(self.ref)
 		self.ref -= 1
 		self.assertEqual(self.ref, 41)
+
+		with self.assertRaises(TypeError):
+			self.ref -= "str"
 
 	def test_InplaceMultiplication(self) -> None:
 		assign_42(self.ref)
 		self.ref *= 1
 		self.assertEqual(self.ref, 42)
 
+		with self.assertRaises(TypeError):
+			self.ref *= "str"
+
 	def test_InplacePower(self) -> None:
 		assign_42(self.ref)
 		self.ref **= 1
 		self.assertEqual(self.ref, 42)
+
+		with self.assertRaises(TypeError):
+			self.ref **= "str"
 
 	def test_InplaceDivision(self) -> None:
 		assign_42(self.ref)
 		self.ref /= 1
 		self.assertEqual(self.ref, 42)
 
+		with self.assertRaises(TypeError):
+			self.ref /= "str"
+
 	def test_InplaceFloorDivision(self) -> None:
 		assign_42(self.ref)
 		self.ref //= 1
 		self.assertEqual(self.ref, 42)
 
+		with self.assertRaises(TypeError):
+			self.ref //= "str"
+
 	def test_InplaceModulo(self) -> None:
 		assign_42(self.ref)
 		self.ref %= 2
 		self.assertEqual(self.ref, 0)
+
+		with self.assertRaises(TypeError):
+			self.ref %= "str"
+
+	def test_InplaceAnd(self) -> None:
+		assign_42(self.ref)
+		self.ref &= 2
+		self.assertEqual(self.ref, 2)
+
+		with self.assertRaises(TypeError):
+			self.ref &= "str"
+
+	def test_InplaceOr(self) -> None:
+		assign_42(self.ref)
+		self.ref |= 1
+		self.assertEqual(self.ref, 43)
+
+		with self.assertRaises(TypeError):
+			self.ref |= "str"
+
+	def test_InplaceXor(self) -> None:
+		assign_42(self.ref)
+		self.ref ^= 2
+		self.assertEqual(self.ref, 40)
+
+		with self.assertRaises(TypeError):
+			self.ref ^= "str"
 
 	def test_TypeConvertToBool(self) -> None:
 		self.assertTrue(bool(self.ref))

--- a/tests/unit/Decorators/Decorators.py
+++ b/tests/unit/Decorators/Decorators.py
@@ -31,7 +31,7 @@
 """Unit tests for Decorators."""
 from unittest import TestCase
 
-from pyTooling.Decorators import InheritDocString, OriginalFunction, ClassProperty
+from pyTooling.Decorators import InheritDocString, OriginalFunction, classproperty
 
 if __name__ == "__main__":  # pragma: no cover
 	print("ERROR: you called a testcase declaration file as an executable module.")
@@ -68,18 +68,19 @@ class Descriptors(TestCase):
 		class Class_1:
 			_member = Content(1)
 
-			@ClassProperty
+			@classproperty
 			def Member(cls):
+				"""Class_1.Member"""
 				return cls._member
 
 			@Member.setter
-			def Member(cls, value):
+			def _Member(cls, value):
 				cls._member = value
 
 		class Class_2:
 			_member = Content(2)
 
-			@ClassProperty
+			@classproperty
 			def Member(cls):
 				return cls._member
 
@@ -89,6 +90,7 @@ class Descriptors(TestCase):
 
 		self.assertEqual(1, Class_1.Member.Value)
 		self.assertEqual(2, Class_2.Member.Value)
+#		self.assertEqual("Class_1.Member", Class_1.Member.__doc__)
 
 		Class_1.Member = 11
 		Class_2.Member = 12

--- a/tests/unit/Packaging/__init__.py
+++ b/tests/unit/Packaging/__init__.py
@@ -47,6 +47,7 @@ if __name__ == "__main__":  # pragma: no cover
 
 
 class HelperFunctions(TestCase):
+	@mark.xfail(version_info > (3, 9), reason="Can fail on MinGW64 with Python 3.10.")
 	def test_VersionInformation(self) -> None:
 		from pyTooling.Packaging import extractVersionInformation
 
@@ -55,6 +56,7 @@ class HelperFunctions(TestCase):
 		self.assertEqual(18, len(versionInformation.Keywords))
 
 	@mark.skipif(version_info < (3, 7), reason="Not supported on Python 3.6, due to dataclass usage in pyTooling.Packaging.")
+	@mark.xfail(version_info > (3, 9), reason="Can fail on MinGW64 with Python 3.10.")
 	def test_loadReadmeMD(self) -> None:
 		from pyTooling.Packaging import loadReadmeFile
 
@@ -62,6 +64,7 @@ class HelperFunctions(TestCase):
 		self.assertIn("# pyTooling", readme.Content)
 		self.assertEqual("text/markdown", readme.MimeType)
 
+	@mark.xfail(version_info > (3, 9), reason="Can fail on MinGW64 with Python 3.10.")
 	def test_loadReadmeReST(self) -> None:
 		from pyTooling.Packaging import loadReadmeFile
 
@@ -69,6 +72,7 @@ class HelperFunctions(TestCase):
 			_ = loadReadmeFile(Path("README.rst"))
 
 	@mark.skipif(version_info < (3, 7), reason="Not supported on Python 3.6, due to dataclass usage in pyTooling.Packaging.")
+	@mark.xfail(version_info > (3, 9), reason="Can fail on MinGW64 with Python 3.10.")
 	def test_loadRequirements(self) -> None:
 		from pyTooling.Packaging import loadRequirementsFile
 
@@ -78,6 +82,7 @@ class HelperFunctions(TestCase):
 
 class VersionInformation(TestCase):
 	@mark.skipif(version_info < (3, 7), reason="Not supported on Python 3.6, due to dataclass usage in pyTooling.Packaging.")
+	@mark.xfail(version_info > (3, 9), reason="Can fail on MinGW64 with Python 3.10.")
 	def test_VersionInformation(self):
 		from pyTooling.Packaging import VersionInformation
 

--- a/tests/unit/Tree/Tree.py
+++ b/tests/unit/Tree/Tree.py
@@ -250,6 +250,12 @@ class Tree(TestCase):
 		size = 1 + len(children) + len(grandChildren) + len(grandGrandChildren)
 		self.assertEqual(size, root.Size)
 
+	def test_Iterator(self):
+		root = Node(1)
+		children = [Node(2, parent=root), Node(3, parent=root)]
+
+		self.assertListEqual(children, [node for node in root])
+
 	def test_Iterate(self):
 		root = Node(1)
 		children = [Node(2, parent=root), Node(3, parent=root)]

--- a/tests/unit/Tree/Tree.py
+++ b/tests/unit/Tree/Tree.py
@@ -228,6 +228,22 @@ class Tree(TestCase):
 
 		self.assertIs("value1", root["key1"])
 
+	def test_Size(self):
+		root = Node(1)
+		children = [Node(2, parent=root), Node(3, parent=root)]
+		grandChildren = [
+			Node(4, parent=children[0]), Node(5, parent=children[0]),
+			Node(6, parent=children[1]), Node(7, parent=children[1])
+		]
+		grandGrandChildren = [
+			Node(8, parent=grandChildren[0]),
+			Node(9, parent=grandChildren[1]), Node(10, parent=grandChildren[1]),
+			Node(11, parent=grandChildren[3])
+		]
+		
+		size = 1 + len(children) + len(grandChildren) + len(grandGrandChildren)
+		self.assertEqual(size, root.Size)
+
 	def test_Iterate(self):
 		root = Node(1)
 		children = [Node(2, parent=root), Node(3, parent=root)]

--- a/tests/unit/Tree/Tree.py
+++ b/tests/unit/Tree/Tree.py
@@ -47,6 +47,7 @@ class Tree(TestCase):
 
 		self.assertIs(root, root.Root)
 		self.assertIsNone(root.Parent)
+		self.assertEqual(0, root.Level)
 		self.assertTrue(root.IsRoot)
 		self.assertTrue(root.IsLeaf)
 		self.assertIs(root, root.GetNodeByID(1))
@@ -57,12 +58,14 @@ class Tree(TestCase):
 
 		self.assertIs(root, root.Root)
 		self.assertIsNone(root.Parent)
+		self.assertEqual(0, root.Level)
 		self.assertTrue(root.IsRoot)
 		self.assertFalse(root.IsLeaf)
 		self.assertTrue(root.HasChildren)
 
 		for child in children:
 			self.assertIs(root, child.Root)
+			self.assertEqual(1, child.Level)
 			self.assertFalse(child.IsRoot)
 			self.assertTrue(child.IsLeaf)
 			self.assertFalse(child.HasChildren)
@@ -80,12 +83,14 @@ class Tree(TestCase):
 
 		self.assertIs(root, root.Root)
 		self.assertIsNone(root.Parent)
+		self.assertEqual(0, root.Level)
 		self.assertTrue(root.IsRoot)
 		self.assertFalse(root.IsLeaf)
 		self.assertTrue(root.HasChildren)
 
 		for child in children:
 			self.assertIs(root, child.Root)
+			self.assertEqual(1, child.Level)
 			self.assertFalse(child.IsRoot)
 			self.assertFalse(child.IsLeaf)
 			self.assertTrue(child.HasChildren)
@@ -97,6 +102,7 @@ class Tree(TestCase):
 
 		for grandChild in grandChildren:
 			self.assertIs(root, grandChild.Root)
+			self.assertEqual(2, grandChild.Level)
 			self.assertFalse(grandChild.IsRoot)
 			self.assertTrue(grandChild.IsLeaf)
 			self.assertFalse(grandChild.HasChildren)
@@ -163,16 +169,46 @@ class Tree(TestCase):
 		root.AddChild(child)
 
 		self.assertIs(root, root.Root)
+		self.assertEqual(0, root.Level)
 		self.assertTrue(root.IsRoot)
 		self.assertTrue(root.HasChildren)
 		self.assertFalse(root.IsLeaf)
 		self.assertListEqual([child], [child for child in root.GetChildren()])
 
 		self.assertIs(root, child.Root)
+		self.assertEqual(1, child.Level)
 		self.assertFalse(child.IsRoot)
 		self.assertTrue(child.IsLeaf)
 		self.assertFalse(child.HasChildren)
 		self.assertIs(root, child.Parent)
+
+	def test_AddChildTree(self):
+		root = Node(1)
+		child = Node(2)
+		grandChild = Node(3, parent=child)
+
+		root.AddChild(child)
+
+		self.assertIs(root, root.Root)
+		self.assertEqual(0, root.Level)
+		self.assertTrue(root.IsRoot)
+		self.assertTrue(root.HasChildren)
+		self.assertFalse(root.IsLeaf)
+		self.assertListEqual([child], [child for child in root.GetChildren()])
+
+		self.assertIs(root, child.Root)
+		self.assertEqual(1, child.Level)
+		self.assertFalse(child.IsRoot)
+		self.assertFalse(child.IsLeaf)
+		self.assertTrue(child.HasChildren)
+		self.assertIs(root, child.Parent)
+
+		self.assertIs(root, grandChild.Root)
+		self.assertEqual(2, grandChild.Level)
+		self.assertFalse(grandChild.IsRoot)
+		self.assertTrue(grandChild.IsLeaf)
+		self.assertFalse(grandChild.HasChildren)
+		self.assertIs(child, grandChild.Parent)
 
 	def test_AddChildren(self):
 		root = Node(1)
@@ -181,6 +217,7 @@ class Tree(TestCase):
 		root.AddChildren(children)
 
 		self.assertIs(root, root.Root)
+		self.assertEqual(0, root.Level)
 		self.assertTrue(root.IsRoot)
 		self.assertTrue(root.HasChildren)
 		self.assertFalse(root.IsLeaf)
@@ -188,6 +225,7 @@ class Tree(TestCase):
 
 		for child in children:
 			self.assertIs(root, child.Root)
+			self.assertEqual(1, child.Level)
 			self.assertFalse(child.IsRoot)
 			self.assertTrue(child.IsLeaf)
 			self.assertFalse(child.HasChildren)
@@ -200,12 +238,14 @@ class Tree(TestCase):
 		child.Parent = root
 
 		self.assertIs(root, root.Root)
+		self.assertEqual(0, root.Level)
 		self.assertTrue(root.IsRoot)
 		self.assertTrue(root.HasChildren)
 		self.assertFalse(root.IsLeaf)
 		self.assertListEqual([child], [child for child in root.GetChildren()])
 
 		self.assertIs(root, child.Root)
+		self.assertEqual(1, child.Level)
 		self.assertFalse(child.IsRoot)
 		self.assertTrue(child.IsLeaf)
 		self.assertFalse(child.HasChildren)
@@ -303,12 +343,23 @@ class Tree(TestCase):
 		root1 = Node(11, parent=children[0])
 		children1 = [Node(12, parent=root1), Node(13, parent=root1)]
 
+		oldSize = root.Size
+
 		root1.Parent = None
 
-		nodes = [root1] + children1
+		self.assertTrue(children[0].IsLeaf)
+		self.assertEqual(0, len(children[0]))
 
+		self.assertEqual(oldSize, root.Size + root1.Size)
+		self.assertEqual(len(children), len(root))
+		self.assertEqual(len(children1), len(root1))
+
+		self.assertIsNone(root1.Parent)
 		self.assertTrue(root1.IsRoot)
-		for node in nodes:
+		self.assertIs(root1, root1.Root)
+		self.assertEqual(0, root1.Level)
+		for node in children1:
 			self.assertIs(root1, node.Root)
+			self.assertEqual(1, node.Level)
 
 		# check if subtree's IDs are not in main tree anymore

--- a/tests/unit/Tree/Tree.py
+++ b/tests/unit/Tree/Tree.py
@@ -228,6 +228,12 @@ class Tree(TestCase):
 
 		self.assertIs("value1", root["key1"])
 
+	def test_Length(self):
+		root = Node(1)
+		children = [Node(2, parent=root), Node(3, parent=root)]
+
+		self.assertEqual(len(children), len(root))
+
 	def test_Size(self):
 		root = Node(1)
 		children = [Node(2, parent=root), Node(3, parent=root)]

--- a/tests/unit/Tree/Tree.py
+++ b/tests/unit/Tree/Tree.py
@@ -246,7 +246,7 @@ class Tree(TestCase):
 			Node(9, parent=grandChildren[1]), Node(10, parent=grandChildren[1]),
 			Node(11, parent=grandChildren[3])
 		]
-		
+
 		size = 1 + len(children) + len(grandChildren) + len(grandGrandChildren)
 		self.assertEqual(size, root.Size)
 


### PR DESCRIPTION
(Replacement PR for erroneous PR #61)

# New Features
* For tree data structure in class `Node`:
  * Implemented property `Level`.
  * Added dunder method `__iter__` to support `iter(...)`.  
    See #59.
  * Added dunder method `__len__` to support `len(...)`.  
    See #60.
  * Added property `Size`.
* New decorator `@classproperty`.

# Changes
* Enhanced unit tests for class `Node`.
* Added missing tests for inplace operators on `CallByRef`.
* Allow unit test failures when running Packaging tests on MinGW64 and Python 3.10.  
  (Somehow Python / pytest on MinGW64 promotes warnings to errors.)

# Bug Fixes
* Fixed bugs when splitting a tree.
