### PR TITLE
v8.5.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @Paebbels
+
+/.github/ @Paebbels

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
       prefix: "[Dependabot]"
     labels:
       - Dependencies
-    reviewers:
-      - Paebbels
     schedule:
       interval: "daily"    # Checks on Monday trough Friday.
 
@@ -21,7 +19,5 @@ updates:
       prefix: "[Dependabot]"
     labels:
       - Dependencies
-    reviewers:
-      - Paebbels
     schedule:
       interval: "weekly"

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -2,7 +2,6 @@ name: Pipeline
 
 on:
   push:
-  create:
   workflow_dispatch:
   schedule:
 # Every Friday at 22:00 - rerun pipeline to check for dependency-based issues

--- a/doc/Dependency.rst
+++ b/doc/Dependency.rst
@@ -130,7 +130,7 @@ the mandatory dependencies too.
 +---------------------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 | `Coverage <https://GitHub.com/nedbat/coveragepy>`__                 | ≥7.8        | `Apache License, 2.0 <https://GitHub.com/nedbat/coveragepy/blob/master/LICENSE.txt>`__ | *Not yet evaluated.* |
 +---------------------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
-| `mypy <https://GitHub.com/python/mypy>`__                           | ≥1.15       | `MIT <https://GitHub.com/python/mypy/blob/master/LICENSE>`__                           | *Not yet evaluated.* |
+| `mypy <https://GitHub.com/python/mypy>`__                           | ≥1.16       | `MIT <https://GitHub.com/python/mypy/blob/master/LICENSE>`__                           | *Not yet evaluated.* |
 +---------------------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+
 | `typing-extensions <https://GitHub.com/python/typing_extensions>`__ | ≥4.13       | `PSF-2.0 <https://github.com/python/typing_extensions/blob/main/LICENSE>`__            | *Not yet evaluated.* |
 +---------------------------------------------------------------------+-------------+----------------------------------------------------------------------------------------+----------------------+

--- a/doc/Glossary.rst
+++ b/doc/Glossary.rst
@@ -107,16 +107,18 @@ Glossary
           classDef mark2 fill:#69f,stroke:#37f;
 
    CLIOption
-     ...
+     undocumented
 
    CLIParameter
-     ...
+     undocumented
 
    CopyLeft
-     ...
+     undocumented
+
+     Wikipedia: :wiki:`Copyleft <Copyleft>`
 
    Cygwin
-     :wiki:`Cygwin` is a :wiki:`POSIX`-compatible programming and runtime environment for Windows.
+     :wiki:`Cygwin <Cygwin>` is a :wiki:`POSIX <POSIX>`-compatible programming and runtime environment for Windows.
 
    DAG
      A *directed acyclic graph* (DAG) is a :term:`directed graph <DG>` without backward edges and therefore free of cycles.
@@ -160,7 +162,7 @@ Glossary
           classDef node fill:#eee,stroke:#777,font-size:smaller;
 
    Decorator
-     ...
+     undocumented
 
    Descendant
      *Descendants* are all direct and indirect successors of a :term:`node` (:term:`child nodes <child>` and child
@@ -203,10 +205,10 @@ Glossary
      An *edge* is a relation from :term:`vertex` to vertex in a :term:`graph`.
 
    Executable
-     ...
+     undocumented
 
    Exception
-     ...
+     undocumented
 
    Graph
      A *graph* is a data structure made of :term:`vertices <vertex>` (nodes) and vertex-vertex relations called
@@ -300,6 +302,9 @@ Glossary
           classDef cur fill:#9e9,stroke:#6e6;
           classDef mark2 fill:#69f,stroke:#37f;
 
+   Hardlink
+     undocumented
+
    Meta-Class
      A *meta-class* is a class helping to construct classes. Thus, it's the type of a type.
 
@@ -327,11 +332,15 @@ Glossary
    MinGW
      Minimalistic GNU for Windows.
 
+     Wikipedia: :wiki:`MinGW <Mingw-w64>`
+
    Mixin-Class
      A *mixin classes* are classes used as secondary base-classes in multiple inheritance.
 
    MSYS2
-     ...
+     undocumented
+
+     Wikipedia: :wiki:`MSYS2 <Mingw-w64#MSYS2>`
 
    Mustoverride Method
      A *must-override* method provides a partial implementation (incomplete code) and must therefore be fully
@@ -345,10 +354,10 @@ Glossary
      MSYS2.
 
    Node
-     ...
+     undocumented
 
    Overloading
-     ...
+     undocumented
 
    Parent
      A *parent* is direct predecessor of a :term:`node`.
@@ -382,19 +391,23 @@ Glossary
           classDef mark2 fill:#69f,stroke:#37f;
 
    Post-Order
-     ...
+     undocumented
 
    Pre-Order
-     ...
+     undocumented
 
    Program
-     ...
+     undocumented
 
    PyPI
-     ...
+     undocumented
+
+     Wikipedia: :wiki:`Python Package Index <Python_Package_Index>`
 
    PyPy
-     ...
+     undocumented
+
+     Wikipedia: :wiki:`PyPy <PyPy>`
 
    Relative
      *Relatives* are :term:`siblings <sibling>` and their :term:`descendants <descendant>`.
@@ -501,7 +514,10 @@ Glossary
      another instance is going to be created, a previously cached instance of that class will be returned.
 
    Slots
-     ...
+     undocumented
+
+   Softlink
+     undocumented
 
    Tree
      A *tree* is a data structure made of :term:`nodes <node>` and parent-child relations. All nodes in a tree share one
@@ -512,17 +528,27 @@ Glossary
    UCRT
      Universal C Runtime
 
+     Wikipedia: :wiki:`Microsoft Windows library files: UCRT <Microsoft_Windows_library_files#UCRT>`
+
    URI
      Uniform Resource Identifier
+
+     Wikipedia: :wiki:`Uniform Resource Identifier <Uniform_Resource_Identifier>`
 
    URL
      Uniform Resource Locator
 
+     Wikipedia: :wiki:`Uniform Resource Locator <URL>`
+
    URN
      Uniform Resource Name
+
+     Wikipedia: :wiki:`Uniform Resource Name <Uniform_Resource_Name>`
 
    Vertex
      A vertex is a :term:`node` in a graph. Vertexes in a graph are connected using :term:`edges <edge>`.
 
    WSL
      Windows System for Linux
+
+     Wikipedia: :wiki:`Windows Subsystem for Linux <Windows_Subsystem_for_Linux>`

--- a/doc/News.rst
+++ b/doc/News.rst
@@ -27,30 +27,43 @@ Version 8.x (2025)
 .. topic:: `v8.1.0 - 25.01.2025 <https://github.com/pyTooling/pyTooling/releases/v8.1.0>`__
 
    * Graph
+
      * Added methods HasVertexByID, HasVertexByValue.
      * Added method GetVertexByValue.
+
    * Versioning
+
      * Version classes are now hashable.
      * Added gamma release level.
+
    * Stopwatch
+
      * Added Exclude context manager
 
 .. topic:: `v8.0.0 - 09.11.2024 <https://github.com/pyTooling/pyTooling/releases/v8.0.0>`__
 
    * Reworked semantic and calendar version classes:
+
      * Moved common implementations to Version base-type.
+
        * Moved major, minor, micro, build, post, dev, release level, release number, hash, prefix, postfix parts to the base-type.
        * Moved implementations of comparison operators to the base-type: __eq__, __ne__, __lt__, __le__, __gt__, __ge__.
        * Implemented minimum comparison operator using __rshift__ (>>) for PIP's ~= operator.
        * Implemented a formatting helper method _format.
+
      * Reworked SemanticVersion.
+
        * Additionally allow comparisons with string and integer types.
        * Enhanced SemanticVersion.Parse() class-method:
+
          * Raise exceptions on invalid inputs.
          * Use a regular expression to check and split the input.
+
      * Implemented CalendarVersion (previously a dummy).
+
        * Added CalendarVersion.Parse() class-method: raise exceptions on invalid inputs.
        * Implemented comparison operators.
+
      * Added validator classes WordSizeValidator and MaxValueValidator.
      * Added doc-strings.
      * Improved __str__() method to return only used version parts.

--- a/pyTooling/Attributes/ArgParse/__init__.py
+++ b/pyTooling/Attributes/ArgParse/__init__.py
@@ -35,6 +35,7 @@ from typing   import Callable, Dict, Tuple, Any, TypeVar
 try:
 	from pyTooling.Decorators  import export, readonly
 	from pyTooling.MetaClasses import ExtendedType
+	from pyTooling.Exceptions  import ToolingException
 	from pyTooling.Common      import firstElement, firstPair
 	from pyTooling.Attributes  import Attribute
 except (ImportError, ModuleNotFoundError):  # pragma: no cover
@@ -43,6 +44,7 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover
 	try:
 		from Decorators          import export, readonly
 		from MetaClasses         import ExtendedType
+		from Exceptions          import ToolingException
 		from Common              import firstElement, firstPair
 		from Attributes          import Attribute
 	except (ImportError, ModuleNotFoundError) as ex:  # pragma: no cover
@@ -51,6 +53,11 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover
 
 
 M = TypeVar("M", bound=Callable)
+
+
+@export
+class ArgParseException(ToolingException):
+	pass
 
 
 #@abstract
@@ -289,7 +296,7 @@ class ArgParseHelperMixin(metaclass=ExtendedType, mixin=True):
 		if (methodCount := len(methods)) == 1:
 			defaultMethod, attributes = firstPair(methods)
 			if len(attributes) > 1:
-				raise Exception("Marked default handler multiple times with 'DefaultAttribute'.")
+				raise ArgParseException("Marked default handler multiple times with 'DefaultAttribute'.")
 
 			# set default handler for the main parser
 			self._mainParser.set_defaults(func=firstElement(attributes).Handler)
@@ -300,7 +307,7 @@ class ArgParseHelperMixin(metaclass=ExtendedType, mixin=True):
 				self._mainParser.add_argument(*methodAttribute.Args, **methodAttribute.KWArgs)
 
 		elif methodCount > 1:
-			raise Exception("Marked more then one handler as default handler with 'DefaultAttribute'.")
+			raise ArgParseException("Marked more then one handler as default handler with 'DefaultAttribute'.")
 
 		# Search for 'CommandHandler' marked methods
 		methods: Dict[Callable, Tuple[CommandHandler]] = self.GetMethodsWithAttributes(predicate=CommandHandler)
@@ -309,7 +316,7 @@ class ArgParseHelperMixin(metaclass=ExtendedType, mixin=True):
 				self._subParser = self._mainParser.add_subparsers(help='sub-command help')
 
 			if len(attributes) > 1:
-				raise Exception("Marked command handler multiple times with 'CommandHandler'.")
+				raise ArgParseException("Marked command handler multiple times with 'CommandHandler'.")
 
 			# Add a sub parser for each command / handler pair
 			attribute = firstElement(attributes)

--- a/pyTooling/Attributes/ArgParse/__init__.py
+++ b/pyTooling/Attributes/ArgParse/__init__.py
@@ -287,6 +287,8 @@ class ArgParseHelperMixin(metaclass=ExtendedType, mixin=True):
 			self._formatter = kwargs["formatter_class"]
 		if "allow_abbrev" not in kwargs:
 			kwargs["allow_abbrev"] = False
+		if "exit_on_error" not in kwargs:
+			kwargs["exit_on_error"] = False
 
 		# create a commandline argument parser
 		self._mainParser = ArgumentParser(**kwargs)

--- a/pyTooling/Common/__init__.py
+++ b/pyTooling/Common/__init__.py
@@ -49,14 +49,15 @@ __issue_tracker__ = "https://GitHub.com/pyTooling/pyTooling/issues"
 
 from collections         import deque
 from numbers             import Number
+from os                  import chdir
 from pathlib             import Path
-from types               import ModuleType
+from types               import ModuleType, TracebackType
 from typing              import Type, TypeVar, Callable, Generator, overload, Hashable, Optional, List
 from typing              import Any, Dict, Tuple, Union, Mapping, Set, Iterable, Optional as Nullable
 
 
 try:
-	from pyTooling.Decorators import export
+	from pyTooling.Decorators  import export
 except ModuleNotFoundError:  # pragma: no cover
 	print("[pyTooling.Common] Could not import from 'pyTooling.*'!")
 
@@ -459,3 +460,29 @@ def zipdicts(*dicts: Tuple[Dict, ...]) -> Generator[Tuple, None, None]:
 			yield key, item0, *(d[key] for d in ds[1:])
 
 	return gen(dicts)
+
+
+@export
+class ChangeDirectory:
+	_oldWorkingDirectory: Path
+	_newWorkingDirectory: Path
+
+	def __init__(self, directory: Path) -> None:
+		self._newWorkingDirectory = directory
+
+	def __enter__(self) -> Path:
+		self._oldWorkingDirectory = Path.cwd()
+		chdir(self._newWorkingDirectory)
+
+		if self._newWorkingDirectory.is_absolute():
+			return self._newWorkingDirectory.resolve()
+		else:
+			return (self._oldWorkingDirectory / self._newWorkingDirectory).resolve()
+
+	def __exit__(
+		self,
+		exc_type: Nullable[Type[BaseException]] = None,
+		exc_val:  Nullable[BaseException] = None,
+		exc_tb:   Nullable[TracebackType] = None
+	) -> Nullable[bool]:
+		chdir(self._oldWorkingDirectory)

--- a/pyTooling/Common/__init__.py
+++ b/pyTooling/Common/__init__.py
@@ -37,7 +37,7 @@ __author__ =        "Patrick Lehmann"
 __email__ =         "Paebbels@gmail.com"
 __copyright__ =     "2017-2025, Patrick Lehmann"
 __license__ =       "Apache License, Version 2.0"
-__version__ =       "8.4.7"
+__version__ =       "8.5.0"
 __keywords__ =      [
 	"abstract", "argparse", "attributes", "bfs", "cli", "console", "data structure", "decorators", "dfs",
 	"double linked list", "exceptions", "file system statistics", "generators", "generic library", "generic path",

--- a/pyTooling/Filesystem/__init__.py
+++ b/pyTooling/Filesystem/__init__.py
@@ -185,12 +185,12 @@ class Directory(Element["Directory"]):
 	While scanning for subelements, the directory is populated with elements. Every file object added, gets registered in
 	the filesystems :class:`Root` for deduplication. In case a file identifier already exists, the found filename will
 	reference the same file objects. In turn, the file objects has then references to multiple filenames (parents). This
-	allows to detect :def:`hardlinks <hardlink>`.
+	allows to detect :term:`hardlinks <hardlink>`.
 
-	The time needed for scanning the directory and its subelements is provided via :attr:`ScanDuration`.
+	The time needed for scanning the directory and its subelements is provided via :data:`ScanDuration`.
 
 	After scnaning the directory for subelements, certain directory properties get aggregated. The time needed for
-	aggregation is provided via :attr:`AggregateDuration`.
+	aggregation is provided via :data:`AggregateDuration`.
 	"""
 
 	_path:              Nullable[Path]             #: Cached :class:`~pathlib.Path` object of this directory.

--- a/pyTooling/TerminalUI/__init__.py
+++ b/pyTooling/TerminalUI/__init__.py
@@ -800,8 +800,14 @@ class TerminalApplication(TerminalBaseApplication):  #, ILineTerminal):
 	_criticalWarningCount: int
 	_warningCount:  int
 
+	HeadLine:       ClassVar[str]
+
 	def __init__(self, mode: Mode = Mode.AllLinearToStdOut) -> None:
-		"""Initializer of a line based terminal interface."""
+		"""
+		Initializer of a line-based terminal interface.
+
+		:param mode: Defines what output (normal, error, data) to write where. Default: a linear flow all to *STDOUT*.
+		"""
 		TerminalBaseApplication.__init__(self)
 		# ILineTerminal.__init__(self, self)
 
@@ -836,6 +842,51 @@ class TerminalApplication(TerminalBaseApplication):  #, ILineTerminal):
 				self._LOG_LEVEL_ROUTING__[severity] =   (self.WriteLineToStdErr, )
 		else:  # pragma: no cover
 			raise ExceptionBase(f"Unsupported mode '{mode}'.")
+
+	def _PrintHeadline(self, width: int = 80) -> None:
+		"""
+		Helper method to print the program headline.
+
+		:param width: Number of characters for horizontal lines.
+
+    .. admonition::
+
+		   .. code-block::
+
+		      =========================
+		          centered headline
+		      =========================
+		"""
+		if width == 0:
+			width = self._width
+
+		self.WriteNormal(f"{{HEADLINE}}{'=' * width}".format(**TerminalApplication.Foreground))
+		self.WriteNormal(f"{{HEADLINE}}{{headline: ^{width}s}}".format(headline=self.HeadLine, **TerminalApplication.Foreground))
+		self.WriteNormal(f"{{HEADLINE}}{'=' * width}".format(**TerminalApplication.Foreground))
+
+	def _PrintVersion(self, author: str, email: str, copyright: str, license: str, version: str) -> None:
+		"""
+		Helper method to print the version information.
+
+		:param author:    Author of the application.
+		:param email:     The author's email address.
+		:param copyright: The copyright information.
+		:param license:   The license.
+		:param version:   The application's version.
+
+    .. admonition::
+
+		   .. code-block:: Python
+
+		      def _PrintVersion(self):
+		        from MyModule import __author__, __email__, __copyright__, __license__, __version__
+
+		        super()._PrintVersion(__author__, __email__, __copyright__, __license__, __version__)
+		"""
+		self.WriteNormal(f"Author:    {author} ({email})")
+		self.WriteNormal(f"Copyright: {copyright}")
+		self.WriteNormal(f"License:   {license}")
+		self.WriteNormal(f"Version:   {version}")
 
 	def Configure(self, verbose: bool = False, debug: bool = False, quiet: bool = False, writeToStdOut: bool = True):
 		self._verbose =       True if debug else verbose

--- a/pyTooling/TerminalUI/__init__.py
+++ b/pyTooling/TerminalUI/__init__.py
@@ -849,7 +849,7 @@ class TerminalApplication(TerminalBaseApplication):  #, ILineTerminal):
 
 		:param width: Number of characters for horizontal lines.
 
-    .. admonition::
+		.. admonition:: Generated output
 
 		   .. code-block::
 
@@ -874,7 +874,7 @@ class TerminalApplication(TerminalBaseApplication):  #, ILineTerminal):
 		:param license:   The license.
 		:param version:   The application's version.
 
-    .. admonition::
+		.. admonition:: Example usage
 
 		   .. code-block:: Python
 

--- a/pyTooling/TerminalUI/__init__.py
+++ b/pyTooling/TerminalUI/__init__.py
@@ -843,13 +843,13 @@ class TerminalApplication(TerminalBaseApplication):  #, ILineTerminal):
 		self._quiet =         quiet
 
 		if quiet:
-			self._writeLevel = Severity.Quiet
+			self._writeLevel =  Severity.Quiet
 		elif debug:
-			self._writeLevel = Severity.Debug
+			self._writeLevel =  Severity.Debug
 		elif verbose:
-			self._writeLevel = Severity.Verbose
+			self._writeLevel =  Severity.Verbose
 		else:
-			self._writeLevel = Severity.Normal
+			self._writeLevel =  Severity.Normal
 
 		self._writeToStdOut = writeToStdOut
 

--- a/run.ps1
+++ b/run.ps1
@@ -33,7 +33,7 @@ Param(
 )
 
 $PackageName = "pyTooling"
-$PackageVersion = "8.4.7"
+$PackageVersion = "8.5.0"
 
 # set default values
 $EnableDebug =        [bool]$PSCmdlet.MyInvocation.BoundParameters["Debug"]
@@ -89,7 +89,7 @@ if ($build)
   rm -Force .\build\bdist.win-amd64
   rm -Force .\build\lib
   Write-Host -ForegroundColor Yellow        "[live][BUILD]      Building $PackageName package as wheel ..."
-  py -3.13 -m build --wheel
+  py -3.13 -m build --wheel --no-isolation
 
   Write-Host -ForegroundColor Yellow        "[live][BUILD]      Building wheel finished"
 }

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
 		sourceFileWithVersion=packageInformationFile,
 		dataFiles={
 			packageName[:-2]: ["py.typed"]
-		}
+		},
+		debug=True
 	)
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,7 +8,7 @@ pytest ~= 8.3
 pytest-cov ~= 6.1
 
 # Static Type Checking
-mypy ~= 1.15
+mypy ~= 1.16
 typing_extensions ~= 4.13
 lxml ~= 5.4
 

--- a/tests/unit/Common/ContextManager.py
+++ b/tests/unit/Common/ContextManager.py
@@ -1,0 +1,71 @@
+# ==================================================================================================================== #
+#             _____           _ _               ____                                                                   #
+#  _ __  _   |_   _|__   ___ | (_)_ __   __ _  / ___|___  _ __ ___  _ __ ___   ___  _ __                               #
+# | '_ \| | | || |/ _ \ / _ \| | | '_ \ / _` || |   / _ \| '_ ` _ \| '_ ` _ \ / _ \| '_ \                              #
+# | |_) | |_| || | (_) | (_) | | | | | | (_| || |__| (_) | | | | | | | | | | | (_) | | | |                             #
+# | .__/ \__, ||_|\___/ \___/|_|_|_| |_|\__, (_)____\___/|_| |_| |_|_| |_| |_|\___/|_| |_|                             #
+# |_|    |___/                          |___/                                                                          #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2017-2025 Patrick Lehmann - Bötzingen, Germany                                                             #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+Unit tests for :class:`~pyTooling.Common.ChangeDirectory`.
+"""
+from pathlib  import Path
+from unittest import TestCase
+
+from pyTooling.Common import ChangeDirectory as ChangeDir
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unittest <testcase module>'")
+	exit(1)
+
+
+class ChangeDirectory(TestCase):
+	def test_ChangeDirectory(self) -> None:
+		before = Path.cwd()
+		path = Path("tests/unit/Common")
+
+		with ChangeDir(path) as p:
+			self.assertEqual(before / path, Path.cwd())
+			self.assertEqual(before / path, p)
+
+		self.assertEqual(before, Path.cwd())
+
+	def test_DoubleChangeDirectory(self) -> None:
+		before = Path.cwd()
+		outerPath = Path("tests/unit/Common")
+		innerPath = Path("../Attributes")
+
+		with ChangeDir(outerPath) as op:
+			self.assertEqual((before / outerPath).resolve(), Path.cwd())
+			self.assertEqual((before / outerPath).resolve(), op)
+
+			with ChangeDir(innerPath) as ip:
+				self.assertEqual((before / outerPath / innerPath).resolve(), Path.cwd())
+				self.assertEqual((before / outerPath / innerPath).resolve(), ip)
+
+			self.assertEqual((before / outerPath).resolve(), Path.cwd())
+
+		self.assertEqual(before, Path.cwd())

--- a/tests/unit/Versioning/CalVersion.py
+++ b/tests/unit/Versioning/CalVersion.py
@@ -102,21 +102,21 @@ class Parsing(TestCase):
 		self.assertEqual(1, version.Major)
 		self.assertEqual(2, version.Minor)
 
-	@mark.xfail(msg="v2024.04 not yet support")
+	@mark.xfail(reason="v2024.04 not yet support")
 	def test_vString(self) -> None:
 		version = CalendarVersion.Parse("v1.2")
 
 		self.assertEqual(1, version.Major)
 		self.assertEqual(2, version.Minor)
 
-	@mark.xfail(msg="i2024.04 not yet support")
+	@mark.xfail(reason="i2024.04 not yet support")
 	def test_iString(self) -> None:
 		version = CalendarVersion.Parse("i1.2")
 
 		self.assertEqual(1, version.Major)
 		self.assertEqual(2, version.Minor)
 
-	@mark.xfail(msg="r2024.04 not yet support")
+	@mark.xfail(reason="r2024.04 not yet support")
 	def test_rString(self) -> None:
 		version = CalendarVersion.Parse("r1.2")
 
@@ -454,7 +454,7 @@ class FormattingUsingRepr(TestCase):
 
 		self.assertEqual("1.0", repr(version))
 
-	@mark.xfail(msg="v2024.04 not yet support")
+	@mark.xfail(reason="v2024.04 not yet support")
 	def test_MajorPrefix(self) -> None:
 		version = CalendarVersion(1, prefix="v")
 
@@ -472,7 +472,7 @@ class FormattingUsingStr(TestCase):
 
 		self.assertEqual("1", str(version))
 
-	@mark.xfail(msg="v2024.04 not yet support")
+	@mark.xfail(reason="v2024.04 not yet support")
 	def test_MajorPrefix(self) -> None:
 		version = CalendarVersion(1, prefix="v")
 


### PR DESCRIPTION
# New Features

* `pyTooling.Common`
  * New context manager `ChangeDirectory`.
* `pyTooling.TerminalUI`
  * New `_PrintHeadline` and `_PrintVersion` methods.

# Changes

* `pyTooling.Attributes.ArgParse`
  * ArgParse raises `ArgParseException` instead of `Exception`.
* `pyTooling.Packaging`
  * Improved print messages using prefix `[pyTooling.Packaging]`.

# Bug Fixes

* `pyTooling.Packaging`:
  * Fixed directory (package) excludes.  
    Compute exclude list based on `scandir`: Exclude all directories except the package namespace itself.
  * Exclude any `__init__.py` from parent namespace (because such a file will break namespace packages without notice by build, pip, ...).

# Documentation

* Fixed ReST syntax (admonitions, indentations, lists).
* Added wikipedia links to glossary.


# Unit Tests

* Improved some testcases.
* New ContextManager testcases.
* Fixed `@mark.xfail` reason messages.
