### PR TITLE
Don't turn a `ClassVar` without an initial value into a slot

### DIFF
--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -733,12 +733,14 @@ class ExtendedType(type):
 					cls = inheritedSlottedFields[fieldName]
 					raise AttributeError(f"Slot '{fieldName}' declared in class '{className}' already exists in base-class '{cls.__module__}.{cls.__name__}'.")
 
-				# If annotated field is a ClassVar, and it has an initial value
-				# * copy field and initial value to classFields dictionary
-				# * remove field from members
-				if isinstance(typeAnnotation, _GenericAlias) and typeAnnotation.__origin__ is ClassVar and fieldName in members:
-					classFields[fieldName] = members[fieldName]
-					del members[fieldName]
+				# If annotated field is a ClassVar, it's never a slot - regardless of an initial value.
+				# * If it has an initial value, copy field and initial value to classFields dictionary
+				#   and remove field from members.
+				# * Otherwise, it's a forward declaration and derived classes assign the actual value.
+				if isinstance(typeAnnotation, _GenericAlias) and typeAnnotation.__origin__ is ClassVar:
+					if fieldName in members:
+						classFields[fieldName] = members[fieldName]
+						del members[fieldName]
 
 				# If an annotated field has an initial value
 				# * copy field and initial value to objectFields dictionary

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -733,13 +733,11 @@ class ExtendedType(type):
 					cls = inheritedSlottedFields[fieldName]
 					raise AttributeError(f"Slot '{fieldName}' declared in class '{className}' already exists in base-class '{cls.__module__}.{cls.__name__}'.")
 
+				# A ClassVar is never a slot, with or without an initial value.
+				# * If it has an initial value, copy field and initial value to classFields dictionary and remove field from members.
+				# * Otherwise it's a forward declaration and derived classes assign the actual value.
 				isClassVariable = isinstance(typeAnnotation, _GenericAlias) and typeAnnotation.__origin__ is ClassVar
 				hasInitialValue = fieldName in members
-
-				# A ClassVar is never a slot, with or without an initial value.
-				# * If it has an initial value, copy field and initial value to classFields dictionary
-				#   and remove field from members.
-				# * Otherwise it's a forward declaration and derived classes assign the actual value.
 				if isClassVariable:
 					if hasInitialValue:
 						classFields[fieldName] = members[fieldName]

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -733,19 +733,22 @@ class ExtendedType(type):
 					cls = inheritedSlottedFields[fieldName]
 					raise AttributeError(f"Slot '{fieldName}' declared in class '{className}' already exists in base-class '{cls.__module__}.{cls.__name__}'.")
 
-				# If annotated field is a ClassVar, it's never a slot - regardless of an initial value.
+				isClassVariable = isinstance(typeAnnotation, _GenericAlias) and typeAnnotation.__origin__ is ClassVar
+				hasInitialValue = fieldName in members
+
+				# A ClassVar is never a slot, with or without an initial value.
 				# * If it has an initial value, copy field and initial value to classFields dictionary
 				#   and remove field from members.
-				# * Otherwise, it's a forward declaration and derived classes assign the actual value.
-				if isinstance(typeAnnotation, _GenericAlias) and typeAnnotation.__origin__ is ClassVar:
-					if fieldName in members:
+				# * Otherwise it's a forward declaration and derived classes assign the actual value.
+				if isClassVariable:
+					if hasInitialValue:
 						classFields[fieldName] = members[fieldName]
 						del members[fieldName]
 
 				# If an annotated field has an initial value
 				# * copy field and initial value to objectFields dictionary
 				# * remove field from members
-				elif fieldName in members:
+				elif hasInitialValue:
 					slottedFields.append(fieldName)
 					objectFields[fieldName] = members[fieldName]
 					del members[fieldName]

--- a/tests/unit/MetaClasses/ClassVariable.py
+++ b/tests/unit/MetaClasses/ClassVariable.py
@@ -77,6 +77,31 @@ class WithoutSlots(TestCase):
 
 
 class WithSlots(TestCase):
+	def test_NoInitValue_NoDunderInit_ClassCheck(self) -> None:
+		class Base(metaclass=ExtendedType, slots=True):
+			_data0: ClassVar[int]
+
+		self.assertNotIn("_data0", Base.__slots__, "Class field '_data0' shouldn't become a slot on class 'Base'.")
+
+		with self.assertRaises(AttributeError, msg="Class field '_data0' shouldn't be initialized on class 'Base'."):
+			_ = Base._data0
+
+	def test_NoInitValue_DerivedAssigned_ClassCheck(self) -> None:
+		"""A ``ClassVar`` without an initial value is a forward declaration: derived classes assign the
+		value. If the base turned it into a slot, the derived class' assignment would shadow the slot
+		descriptor and make the field read-only on instances."""
+		class Base(metaclass=ExtendedType, slots=True):
+			_data0: ClassVar[int]
+
+		class Derived(Base):
+			_data0 = 2
+
+		self.assertEqual(2, Derived._data0)
+
+		derived = Derived()
+
+		self.assertEqual(2, derived._data0)
+
 	def test_InitValue_NoDunderInit_ClassCheck(self) -> None:
 		class Base(metaclass=ExtendedType, slots=True):
 			_data0: ClassVar[int] = 1

--- a/tests/unit/MetaClasses/ClassVariable.py
+++ b/tests/unit/MetaClasses/ClassVariable.py
@@ -92,15 +92,20 @@ class WithSlots(TestCase):
 		descriptor and make the field read-only on instances."""
 		class Base(metaclass=ExtendedType, slots=True):
 			_data0: ClassVar[int]
+			_data1: ClassVar[int] = 1
 
 		class Derived(Base):
-			_data0 = 2
+			_data0: ClassVar[int] = 2
+			_data1: ClassVar[int] = 3
 
+		self.assertEqual(1, Base._data1)
 		self.assertEqual(2, Derived._data0)
+		self.assertEqual(3, Derived._data1)
 
 		derived = Derived()
 
 		self.assertEqual(2, derived._data0)
+		self.assertEqual(3, derived._data1)
 
 	def test_InitValue_NoDunderInit_ClassCheck(self) -> None:
 		class Base(metaclass=ExtendedType, slots=True):


### PR DESCRIPTION
## Problem

`ExtendedType` only recognised a `ClassVar[...]` annotation when the field also carried an initial value:

```py
if isinstance(typeAnnotation, _GenericAlias) and typeAnnotation.__origin__ is ClassVar and fieldName in members:
```

Without a value, the field failed that condition and fell through to the `else` branch that appends to `slottedFields` — so it silently became a `__slots__` entry.

That breaks the forward-declaration form, where a base class declares the field and derived classes supply the value:

```py
class A(metaclass=ExtendedType, slots=True):
	_bare: ClassVar[Tuple[str, str]]      # A.__slots__ == ('_bare',)  ← should be ()

class B(A):
	_bare = ("(", ")")                    # shadows the slot descriptor

B()._bare = ...
# AttributeError: 'B' object attribute '_bare' is read-only
```

Two consequences:

1. The attribute is **read-only on instances** of every derived class.
2. Such objects are **unpicklable** — `pickle`'s default `__setstate__` writes every slot back, and hits the same `AttributeError`.

Adding an initial value to the base declaration is enough to work around it (`A.__slots__` becomes `()`), which is what makes the behaviour so easy to miss.

## Fix

A `ClassVar` is never instance state, so it must not become a slot whether or not it has an initial value. Detect it first, and only copy it into `classFields` when a value is actually present.

## Tests

`WithoutSlots` already covered the value-less form; `WithSlots` did not — exactly the gap. Added two cases there:

* `test_NoInitValue_NoDunderInit_ClassCheck` — asserts the field stays out of `__slots__`.
* `test_NoInitValue_DerivedAssigned_ClassCheck` — the pattern that actually breaks: base declares, derived assigns, value readable from class and instance.

Full suite on Python 3.14: **1156 passed, 33 skipped, 8 xfailed**.

## Where it turned up

In `pyVHDLModel`, where `UnaryExpression._FORMAT`, `BinaryExpression._FORMAT`, `TernaryExpression._FORMAT` and `RangeExpression._direction` are declared on abstract bases and assigned by 48 concrete subclasses. `Expression.py:1977` carries a standing `# FIXME: needs ClassVar[...] when pyTooling gets fixed.` — this is that fix, and the FIXME can go.

Verified downstream against this branch: pyVHDLModel's suite stays green (461 passed) with the annotations switched to the value-less `ClassVar[...]` form, and a parsed OSVVM design (43 documents, ~28.5k lines of VHDL) then pickles and round-trips cleanly — which was impossible before.

Note for sequencing: `pyVHDLModel` currently pins `pyTooling ~= 8.17`, so it can only adopt the clean form once this ships in 8.18.
