### PR TITLE
Work through 10 findings: MetaClasses FIXMEs, empty exception messages, @readonly, CalendarVersion

### DIFF
--- a/doc/Decorators.rst
+++ b/doc/Decorators.rst
@@ -24,7 +24,7 @@ Abstract Methods
 
       .. todo::
 
-         DECO:: Refer to :func:`~pyTooling.MetaClasses.abstractmethod` and :func:`~pyTooling.MetaClasses.mustoverride`
+         DECO:: Refer to :deco:`~pyTooling.MetaClasses.abstractmethod` and :deco:`~pyTooling.MetaClasses.mustoverride`
          decorators from :ref:`meta classes <META>`.
 
       .. important::
@@ -45,7 +45,7 @@ Abstract Methods
    .. grid-item::
       :columns: 6
 
-      The :func:`~pyTooling.MetaClasses.abstractmethod` decorator marks a method as *abstract*.
+      The :deco:`~pyTooling.MetaClasses.abstractmethod` decorator marks a method as *abstract*.
 
       The original method gets replaced by a method raising a :exc:`NotImplementedError`. This can happen, if an
       abstract method is overridden but called via :pycode:`super()...`.
@@ -88,7 +88,7 @@ Abstract Methods
    .. grid-item::
       :columns: 6
 
-      The :func:`~pyTooling.MetaClasses.mustoverride` decorator marks a method as *must override*.
+      The :deco:`~pyTooling.MetaClasses.mustoverride` decorator marks a method as *must override*.
 
       When a class containing *must override* methods is instantiated, an :exc:`~pyTooling.Exceptions.MustOverrideClassError`
       is raised.
@@ -139,7 +139,7 @@ Data Access
    .. grid-item::
       :columns: 6
 
-      The :func:`~pyTooling.Decorators.readonly` decorator makes a property *read-only*. Thus the properties
+      The :deco:`~pyTooling.Decorators.readonly` decorator makes a property *read-only*. Thus the properties
       :pycode:`setter` and :pycode:`deleter` can't be used.
 
    .. grid-item::
@@ -186,7 +186,7 @@ Documentation
    .. grid-item::
       :columns: 6
 
-      The :func:`~pyTooling.Decorators.export` decorator makes module's entities (classes and functions) publicly
+      The :deco:`~pyTooling.Decorators.export` decorator makes module's entities (classes and functions) publicly
       visible. Therefore, these entities get registered in the module's variable ``__all__``.
 
       Besides making these entities accessible via ``from foo import *``, Sphinx extensions like autoapi are reading
@@ -233,7 +233,7 @@ Documentation
       :columns: 6
 
       When a method in a derived class shall have the same doc-string as the doc-string of the base-class, then the
-      decorator :func:`~pyTooling.Decorators.InheritDocString` can be used to copy the doc-string from base-class'
+      decorator :deco:`~pyTooling.Decorators.InheritDocString` can be used to copy the doc-string from base-class'
       method to the method in the derived class.
 
    .. grid-item::
@@ -452,7 +452,7 @@ Miscellaneous
    .. grid-item::
       :columns: 6
 
-      The :func:`~pyTooling.Decorators.notimplemented` decorator replaces a callable (function or method) with a
+      The :deco:`~pyTooling.Decorators.notimplemented` decorator replaces a callable (function or method) with a
       callable raising a :exc:`NotImplementedError` containing the decorators message parameter as an error message.
 
       The original callable might contain code, but it's made unreachable by the decorator. The callable's name and

--- a/doc/MetaClasses.rst
+++ b/doc/MetaClasses.rst
@@ -49,7 +49,7 @@ Mixin
 Abstract Method
 ***************
 
-The :func:`~pyTooling.MetaClasses.abstractmethod` decorator marks a method as *abstract*. The original method gets
+The :deco:`~pyTooling.MetaClasses.abstractmethod` decorator marks a method as *abstract*. The original method gets
 replaced by a method raising a :exc:`NotImplementedError`. When a class containing *abstract* methods is
 instantiated, an :exc:`~pyTooling.Exceptions.AbstractClassError` is raised.
 
@@ -76,7 +76,7 @@ instantiated, an :exc:`~pyTooling.Exceptions.AbstractClassError` is raised.
 MustOverwrite Method
 ********************
 
-The :func:`~pyTooling.MetaClasses.mustoverride` decorator marks a method as *must override*. When a class containing
+The :deco:`~pyTooling.MetaClasses.mustoverride` decorator marks a method as *must override*. When a class containing
 *must override* methods is instantiated, an :exc:`~pyTooling.Exceptions.MustOverrideClassError` is raised.
 
 In contrast to :ref:`@abstractmethod <META/Abstract>`, the method can still be called from a derived class

--- a/pyTooling/Cartesian2D/__init__.py
+++ b/pyTooling/Cartesian2D/__init__.py
@@ -31,7 +31,7 @@
 """An implementation of 2D cartesian data structures for Python."""
 
 from math   import sqrt, acos
-from typing import TypeVar, Union, Generic, Any, Tuple
+from typing import TypeVar, Union, Generic, Any, Tuple, Self
 
 from pyTooling.Decorators  import readonly, export
 from pyTooling.MetaClasses import ExtendedType
@@ -68,7 +68,7 @@ class Point2D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		self.x = x
 		self.y = y
 
-	def Copy(self) -> "Point2D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def Copy(self) -> Self:
 		"""
 		Create a new 2D-point as a copy of this 2D point.
 
@@ -114,7 +114,7 @@ class Point2D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 			ex.add_note(f"Got type '{getFullyQualifiedName(other)}'.")
 			raise ex
 
-	def __iadd__(self, other: Any) -> "Point2D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def __iadd__(self, other: Any) -> Self:
 		"""
 		Adds a 2D-offset to this 2D-point (inplace).
 
@@ -153,7 +153,7 @@ class Point2D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 			ex.add_note(f"Got type '{getFullyQualifiedName(other)}'.")
 			raise ex
 
-	def __isub__(self, other: Any) -> "Point2D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def __isub__(self, other: Any) -> Self:
 		"""
 		Subtracts a 2D-offset to this 2D-point (inplace).
 
@@ -201,7 +201,7 @@ class Origin2D(Point2D[Coordinate], Generic[Coordinate]):
 		"""
 		super().__init__(0, 0)
 
-	def Copy(self) -> "Origin2D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def Copy(self) -> Self:
 		"""
 		:raises RuntimeError: Because an origin can't be copied.
 		"""
@@ -243,7 +243,7 @@ class Offset2D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		self.xOffset = xOffset
 		self.yOffset = yOffset
 
-	def Copy(self) -> "Offset2D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def Copy(self) -> Self:
 		"""
 		Create a new 2D-offset as a copy of this 2D-offset.
 
@@ -327,7 +327,7 @@ class Offset2D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 			ex.add_note(f"Got type '{getFullyQualifiedName(other)}'.")
 			raise ex
 
-	def __iadd__(self, other: Any) -> "Offset2D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def __iadd__(self, other: Any) -> Self:
 		"""
 		Adds a 2D-offset to this 2D-offset (inplace).
 
@@ -371,7 +371,7 @@ class Offset2D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 			ex.add_note(f"Got type '{getFullyQualifiedName(other)}'.")
 			raise ex
 
-	def __isub__(self, other: Any) -> "Offset2D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def __isub__(self, other: Any) -> Self:
 		"""
 		Subtracts a 2D-offset from this 2D-offset (inplace).
 
@@ -436,7 +436,7 @@ class Size2D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		self.width = width
 		self.height = height
 
-	def Copy(self) -> "Size2D":  # TODO: Python 3.11: -> Self:
+	def Copy(self) -> Self:
 		"""
 		Create a new 2D-size as a copy of this 2D-size.
 

--- a/pyTooling/Cartesian3D/__init__.py
+++ b/pyTooling/Cartesian3D/__init__.py
@@ -31,7 +31,7 @@
 """An implementation of 3D cartesian data structures for Python."""
 
 from math   import sqrt, acos
-from typing import Union, Generic, Any, Tuple
+from typing import Union, Generic, Any, Tuple, Self
 
 from pyTooling.Decorators  import readonly, export
 from pyTooling.MetaClasses import ExtendedType
@@ -73,7 +73,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		self.y = y
 		self.z = z
 
-	def Copy(self) -> "Point3D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def Copy(self) -> Self:
 		"""
 		Create a new 3D-point as a copy of this 3D point.
 
@@ -121,7 +121,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 			ex.add_note(f"Got type '{getFullyQualifiedName(other)}'.")
 			raise ex
 
-	def __iadd__(self, other: Any) -> "Point3D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def __iadd__(self, other: Any) -> Self:
 		"""
 		Adds a 3D-offset to this 3D-point (inplace).
 
@@ -163,7 +163,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 			ex.add_note(f"Got type '{getFullyQualifiedName(other)}'.")
 			raise ex
 
-	def __isub__(self, other: Any) -> "Point3D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def __isub__(self, other: Any) -> Self:
 		"""
 		Subtracts a 3D-offset to this 3D-point (inplace).
 
@@ -213,7 +213,7 @@ class Origin3D(Point3D[Coordinate], Generic[Coordinate]):
 		"""
 		super().__init__(0, 0, 0)
 
-	def Copy(self) -> "Origin3D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def Copy(self) -> Self:
 		"""
 		:raises RuntimeError: Because an origin can't be copied.
 		"""
@@ -262,7 +262,7 @@ class Offset3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		self.yOffset = yOffset
 		self.zOffset = zOffset
 
-	def Copy(self) -> "Offset3D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def Copy(self) -> Self:
 		"""
 		Create a new 3D-offset as a copy of this 3D-offset.
 
@@ -349,7 +349,7 @@ class Offset3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 			ex.add_note(f"Got type '{getFullyQualifiedName(other)}'.")
 			raise ex
 
-	def __iadd__(self, other: Any) -> "Offset3D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def __iadd__(self, other: Any) -> Self:
 		"""
 		Adds a 3D-offset to this 3D-offset (inplace).
 
@@ -397,7 +397,7 @@ class Offset3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 			ex.add_note(f"Got type '{getFullyQualifiedName(other)}'.")
 			raise ex
 
-	def __isub__(self, other: Any) -> "Offset3D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def __isub__(self, other: Any) -> Self:
 		"""
 		Subtracts a 3D-offset from this 3D-offset (inplace).
 
@@ -471,7 +471,7 @@ class Size3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		self.height = height
 		self.depth =  depth
 
-	def Copy(self) -> "Size3D[Coordinate]":  # TODO: Python 3.11: -> Self:
+	def Copy(self) -> Self:
 		"""
 		Create a new 3D-size as a copy of this 3D-size.
 

--- a/pyTooling/Configuration/JSON.py
+++ b/pyTooling/Configuration/JSON.py
@@ -37,11 +37,14 @@ Configuration reader for JSON files.
 """
 from json          import load
 from pathlib       import Path
-from typing import Dict, List, Union, Iterator as typing_Iterator, Self
+from typing import Any, Dict, List, Union, Iterator as typing_Iterator, Self
 
+from pyTooling.Common          import getFullyQualifiedName
 from pyTooling.Decorators      import export
 from pyTooling.MetaClasses     import ExtendedType
 from pyTooling.Configuration   import ConfigurationException, KeyT, NodeT, ValueT
+from pyTooling.Configuration   import InterpolationException, KeyNotFoundException, PathExpressionException
+from pyTooling.Configuration   import UnsupportedValueTypeException
 from pyTooling.Configuration   import Node as Abstract_Node
 from pyTooling.Configuration   import Dictionary as Abstract_Dict
 from pyTooling.Configuration   import Sequence as Abstract_Seq
@@ -125,20 +128,57 @@ class Node(Abstract_Node):
 	def _ToPath(query: str) -> List[Union[str, int]]:
 		return query.split(":")
 
+	def _LookupKey(self, key: str) -> Any:
+		"""
+		Look up a key in the JSON node, trying it as string, integer and float.
+
+		:param key:                   Key or index to look up.
+		:returns:                     The raw value as returned by the JSON parser.
+		:raises KeyNotFoundException: If the key exists neither as string, nor as integer or float.
+		"""
+		try:
+			return self._jsonNode[key]
+		except (KeyError, TypeError):
+			pass
+
+		for conversion in (int, float):
+			try:
+				convertedKey = conversion(key)
+			except ValueError:
+				continue
+
+			try:
+				return self._jsonNode[convertedKey]
+			except (KeyError, IndexError, TypeError):
+				pass
+
+		ex = KeyNotFoundException(f"Key '{key}' not found in node '{self._key}'.")
+		ex.add_note(self._DescribeKeys())
+		raise ex
+
+	def _DescribeKeys(self) -> str:
+		"""
+		Describe the keys or indices offered by this node, so it can be used as an exception note.
+
+		:returns: A one-line description of the node's keys or index range.
+		"""
+		if isinstance(self._jsonNode, dict):
+			if self._length == 0:
+				return f"Node '{self._key}' is an empty dictionary."
+
+			keys = "', '".join(str(key) for key in self._jsonNode)
+			return f"Available keys: '{keys}'."
+		else:
+			if self._length == 0:
+				return f"Node '{self._key}' is an empty sequence."
+
+			return f"Node '{self._key}' is a sequence with indices 0..{self._length - 1}."
+
 	def _GetNodeOrValue(self, key: str) -> ValueT:
 		try:
 			value = self._cache[key]
 		except KeyError:
-			try:
-				value = self._jsonNode[key]
-			except (KeyError, TypeError):
-				try:
-					value = self._jsonNode[int(key)]
-				except KeyError:
-					try:
-						value = self._jsonNode[float(key)]
-					except KeyError as ex:
-						raise Exception(f"") from ex         # XXX: needs error message
+			value = self._LookupKey(key)
 
 			if isinstance(value, str):
 				value = self._ResolveVariables(value)
@@ -149,7 +189,10 @@ class Node(Abstract_Node):
 			elif isinstance(value, list):
 				value = self.SEQ_TYPE(self, self, key, value)
 			else:
-				raise Exception(f"") from TypeError(f"Unknown type '{value.__class__.__name__}' returned from json.") # XXX: error message
+				typeName = getFullyQualifiedName(value)
+				ex = UnsupportedValueTypeException(f"Unsupported type '{typeName}' for key '{key}' in node '{self._key}'.")
+				ex.add_note(f"The JSON parser returned a value that is neither a scalar (str, int, float), nor a dict or list.")
+				raise ex
 
 			self._cache[key] = value
 
@@ -172,14 +215,20 @@ class Node(Abstract_Node):
 				rawValue = ""
 			else:
 				result += rawValue[:beginPos]
-				if rawValue[beginPos + 1] == "$":
+				if beginPos + 1 >= len(rawValue):
+					ex = InterpolationException(f"Dangling '$' at the end of value '{value}'.")
+					ex.add_note(f"Use '$$' to escape a literal dollar sign.")
+					raise ex
+				elif rawValue[beginPos + 1] == "$":
 					result  += "$"
 					rawValue = rawValue[1:]
 				elif rawValue[beginPos + 1] == "{":
 					endPos =  rawValue.find("}", beginPos)
 					nextPos =  rawValue.rfind("$", beginPos, endPos)
 					if endPos < 0:
-						raise Exception(f"")  # XXX: InterpolationSyntaxError(option, section, f"Bad interpolation variable reference {rest!r}")
+						ex = InterpolationException(f"Unclosed variable reference in value '{value}'.")
+						ex.add_note(f"Missing closing '}}' for the '${{' at position {beginPos}.")
+						raise ex
 					if (nextPos > 0) and (nextPos < endPos):  # an embedded $-sign
 						path = rawValue[nextPos+2:endPos]
 #						print(f"_ResolveVariables: path='{path}'")
@@ -203,7 +252,10 @@ class Node(Abstract_Node):
 				node = node._GetNodeOrValue(p)
 
 		if isinstance(node, Dictionary):
-			raise Exception(f"Error when resolving path expression '{':'.join(path)}' at '{p}'.") from TypeError(f"")     # XXX: needs error messages
+			pathExpression = ":".join(str(element) for element in path)
+			ex = PathExpressionException(f"Path expression '{pathExpression}' resolves to a dictionary, not to a value.")
+			ex.add_note(f"Element '{p}' is a dictionary. Extend the path expression to address a scalar value.")
+			raise ex
 
 		return node
 
@@ -354,12 +406,12 @@ class Sequence(Node, Abstract_Seq):
 				:returns:              Next item.
 				:raises StopIteration: If end of sequence is reached.
 				"""
-				try:
-					result = self._obj[str(self._i)]
-					self._i += 1
-					return result
-				except IndexError:
+				if self._i >= len(self._obj):
 					raise StopIteration
+
+				result = self._obj[str(self._i)]
+				self._i += 1
+				return result
 
 		return Iterator(self)
 

--- a/pyTooling/Configuration/JSON.py
+++ b/pyTooling/Configuration/JSON.py
@@ -37,7 +37,7 @@ Configuration reader for JSON files.
 """
 from json          import load
 from pathlib       import Path
-from typing import Any, Dict, List, Union, Iterator as typing_Iterator, Self
+from typing        import Any, Dict, List, Union, Iterator as typing_Iterator, Self
 
 from pyTooling.Common          import getFullyQualifiedName
 from pyTooling.Decorators      import export

--- a/pyTooling/Configuration/YAML.py
+++ b/pyTooling/Configuration/YAML.py
@@ -36,16 +36,19 @@ Configuration reader for YAML files.
    See :ref:`high-level help <CONFIG/FileFormat/YAML>` for explanations and usage examples.
 """
 from pathlib       import Path
-from typing        import Dict, List, Union, Iterator as typing_Iterator, Self
+from typing        import Any, Dict, List, Union, Iterator as typing_Iterator, Self
 
 try:
 	from ruamel.yaml import YAML, CommentedMap, CommentedSeq
 except ImportError as ex:  # pragma: no cover
 	raise Exception("Optional dependency 'ruamel.yaml' not installed. Either install pyTooling with extra dependencies 'pyTooling[yaml]' or install 'ruamel.yaml' directly.") from ex
 
+from pyTooling.Common          import getFullyQualifiedName
 from pyTooling.Decorators      import export
 from pyTooling.MetaClasses     import ExtendedType
 from pyTooling.Configuration   import ConfigurationException, KeyT, NodeT, ValueT
+from pyTooling.Configuration   import InterpolationException, KeyNotFoundException, PathExpressionException
+from pyTooling.Configuration   import UnsupportedValueTypeException
 from pyTooling.Configuration   import Node as Abstract_Node
 from pyTooling.Configuration   import Dictionary as Abstract_Dict
 from pyTooling.Configuration   import Sequence as Abstract_Seq
@@ -129,20 +132,57 @@ class Node(Abstract_Node):
 	def _ToPath(query: str) -> List[Union[str, int]]:
 		return query.split(":")
 
+	def _LookupKey(self, key: str) -> Any:
+		"""
+		Look up a key in the YAML node, trying it as string, integer and float.
+
+		:param key:                   Key or index to look up.
+		:returns:                     The raw value as returned by the YAML parser.
+		:raises KeyNotFoundException: If the key exists neither as string, nor as integer or float.
+		"""
+		try:
+			return self._yamlNode[key]
+		except (KeyError, TypeError):
+			pass
+
+		for conversion in (int, float):
+			try:
+				convertedKey = conversion(key)
+			except ValueError:
+				continue
+
+			try:
+				return self._yamlNode[convertedKey]
+			except (KeyError, IndexError, TypeError):
+				pass
+
+		ex = KeyNotFoundException(f"Key '{key}' not found in node '{self._key}'.")
+		ex.add_note(self._DescribeKeys())
+		raise ex
+
+	def _DescribeKeys(self) -> str:
+		"""
+		Describe the keys or indices offered by this node, so it can be used as an exception note.
+
+		:returns: A one-line description of the node's keys or index range.
+		"""
+		if isinstance(self._yamlNode, CommentedMap):
+			if self._length == 0:
+				return f"Node '{self._key}' is an empty dictionary."
+
+			keys = "', '".join(str(key) for key in self._yamlNode)
+			return f"Available keys: '{keys}'."
+		else:
+			if self._length == 0:
+				return f"Node '{self._key}' is an empty sequence."
+
+			return f"Node '{self._key}' is a sequence with indices 0..{self._length - 1}."
+
 	def _GetNodeOrValue(self, key: str) -> ValueT:
 		try:
 			value = self._cache[key]
 		except KeyError:
-			try:
-				value = self._yamlNode[key]
-			except (KeyError, TypeError):
-				try:
-					value = self._yamlNode[int(key)]
-				except KeyError:
-					try:
-						value = self._yamlNode[float(key)]
-					except KeyError as ex:
-						raise Exception(f"") from ex         # XXX: needs error message
+			value = self._LookupKey(key)
 
 			if isinstance(value, str):
 				value = self._ResolveVariables(value)
@@ -153,7 +193,10 @@ class Node(Abstract_Node):
 			elif isinstance(value, CommentedSeq):
 				value = self.SEQ_TYPE(self, self, key, value)
 			else:
-				raise Exception(f"") from TypeError(f"Unknown type '{value.__class__.__name__}' returned from ruamel.yaml.") # XXX: error message
+				typeName = getFullyQualifiedName(value)
+				ex = UnsupportedValueTypeException(f"Unsupported type '{typeName}' for key '{key}' in node '{self._key}'.")
+				ex.add_note(f"The YAML parser returned a value that is neither a scalar (str, int, float), nor a map or sequence.")
+				raise ex
 
 			self._cache[key] = value
 
@@ -176,14 +219,20 @@ class Node(Abstract_Node):
 				rawValue = ""
 			else:
 				result += rawValue[:beginPos]
-				if rawValue[beginPos + 1] == "$":
+				if beginPos + 1 >= len(rawValue):
+					ex = InterpolationException(f"Dangling '$' at the end of value '{value}'.")
+					ex.add_note(f"Use '$$' to escape a literal dollar sign.")
+					raise ex
+				elif rawValue[beginPos + 1] == "$":
 					result  += "$"
 					rawValue = rawValue[1:]
 				elif rawValue[beginPos + 1] == "{":
 					endPos =  rawValue.find("}", beginPos)
 					nextPos =  rawValue.rfind("$", beginPos, endPos)
 					if endPos < 0:
-						raise Exception(f"")  # XXX: InterpolationSyntaxError(option, section, f"Bad interpolation variable reference {rest!r}")
+						ex = InterpolationException(f"Unclosed variable reference in value '{value}'.")
+						ex.add_note(f"Missing closing '}}' for the '${{' at position {beginPos}.")
+						raise ex
 					if (nextPos > 0) and (nextPos < endPos):  # an embedded $-sign
 						path = rawValue[nextPos+2:endPos]
 #						print(f"_ResolveVariables: path='{path}'")
@@ -207,7 +256,10 @@ class Node(Abstract_Node):
 				node = node._GetNodeOrValue(p)
 
 		if isinstance(node, Dictionary):
-			raise Exception(f"Error when resolving path expression '{':'.join(path)}' at '{p}'.") from TypeError(f"")     # XXX: needs error messages
+			pathExpression = ":".join(str(element) for element in path)
+			ex = PathExpressionException(f"Path expression '{pathExpression}' resolves to a dictionary, not to a value.")
+			ex.add_note(f"Element '{p}' is a dictionary. Extend the path expression to address a scalar value.")
+			raise ex
 
 		return node
 
@@ -357,12 +409,12 @@ class Sequence(Node, Abstract_Seq):
 				:returns:              Next item.
 				:raises StopIteration: If end of sequence is reached.
 				"""
-				try:
-					result = self._obj[str(self._i)]
-					self._i += 1
-					return result
-				except IndexError:
+				if self._i >= len(self._obj):
 					raise StopIteration
+
+				result = self._obj[str(self._i)]
+				self._i += 1
+				return result
 
 		return Iterator(self)
 

--- a/pyTooling/Configuration/__init__.py
+++ b/pyTooling/Configuration/__init__.py
@@ -57,6 +57,35 @@ class ConfigurationException(ToolingException):
 
 
 @export
+class KeyNotFoundException(ConfigurationException):
+	"""
+	The requested key or index doesn't exist in the configuration node.
+
+	The key was neither found as a string, nor converted to an integer or float. A note lists the keys or the index
+	range offered by the node.
+	"""
+
+
+@export
+class UnsupportedValueTypeException(ConfigurationException):
+	"""
+	The configuration file parser returned a value of a type that isn't supported by :mod:`pyTooling.Configuration`.
+
+	Supported are scalars (:class:`str`, :class:`int`, :class:`float`) and the parser's dictionary and sequence types.
+	"""
+
+
+@export
+class InterpolationException(ConfigurationException):
+	"""A variable reference (``${...}``) in a configuration value is malformed or can't be resolved."""
+
+
+@export
+class PathExpressionException(ConfigurationException):
+	"""A path expression (``a:b:c``) doesn't describe a valid node or value in the configuration."""
+
+
+@export
 class Node(metaclass=ExtendedType, slots=True):
 	"""Abstract node in a configuration data structure."""
 

--- a/pyTooling/Decorators/__init__.py
+++ b/pyTooling/Decorators/__init__.py
@@ -37,7 +37,7 @@
 import sys
 from functools import wraps
 from types     import FunctionType
-from typing    import Union, Type, TypeVar, Callable
+from typing    import Union, Type, TypeVar, Callable, NoReturn
 
 __all__ = ["export", "Param", "RetType", "Func", "T"]
 
@@ -156,13 +156,51 @@ def notimplemented(message: str) -> Callable:
 
 
 @export
-def readonly(func: Callable) -> property:
+class ReadOnlyProperty(property):
+	"""
+	A :class:`property` that rejects attaching a setter or a deleter.
+
+	A plain :class:`property` hands out ``<property>.setter`` and ``<property>.deleter``, so a property declared as
+	read-only could be made writable again further down the class body - and the declaration would silently become a
+	lie. Both methods therefore raise an :exc:`AttributeError` instead.
+
+	.. seealso::
+
+	   :func:`~pyTooling.Decorators.readonly`
+	     The decorator creating a read-only property.
+	"""
+
+	def setter(self, fset: Callable) -> NoReturn:
+		"""
+		Reject attaching a setter to a read-only property.
+
+		:param fset:            The setter-method that was to be attached.
+		:raises AttributeError: Always, because a read-only property can't have a setter.
+		"""
+		ex = AttributeError(f"Property '{self.fget.__name__}' is read-only, so it can't have a setter.")
+		ex.add_note(f"Use '@property' instead of '@readonly', if the property should be writable.")
+		raise ex
+
+	def deleter(self, fdel: Callable) -> NoReturn:
+		"""
+		Reject attaching a deleter to a read-only property.
+
+		:param fdel:            The deleter-method that was to be attached.
+		:raises AttributeError: Always, because a read-only property can't have a deleter.
+		"""
+		ex = AttributeError(f"Property '{self.fget.__name__}' is read-only, so it can't have a deleter.")
+		ex.add_note(f"Use '@property' instead of '@readonly', if the property should be deletable.")
+		raise ex
+
+
+@export
+def readonly(func: Callable) -> ReadOnlyProperty:
 	"""
 	Marks a property as *read-only*.
 
 	The doc-string will be taken from the getter-function.
 
-	It will remove ``<property>.setter`` and ``<property>.deleter`` from the property descriptor.
+	Using ``<property>.setter`` or ``<property>.deleter`` on the result raises an :exc:`AttributeError`.
 
 	:param func: Function to convert to a read-only property.
 	:returns:    A property object with just a getter.
@@ -171,10 +209,10 @@ def readonly(func: Callable) -> property:
 
 	   :class:`property`
 	     A decorator to convert getter, setter and deleter methods into a property applying the descriptor protocol.
+	   :class:`~pyTooling.Decorators.ReadOnlyProperty`
+	     The property type returned by this decorator.
 	"""
-	prop = property(fget=func, fset=None, fdel=None, doc=func.__doc__)
-
-	return prop
+	return ReadOnlyProperty(fget=func, fset=None, fdel=None, doc=func.__doc__)
 
 
 @export

--- a/pyTooling/Decorators/__init__.py
+++ b/pyTooling/Decorators/__init__.py
@@ -140,8 +140,8 @@ def notimplemented(message: str) -> Callable:
 
 	.. seealso::
 
-	   * :func:`~pyTooling.Metaclasses.abstractmethod`
-	   * :func:`~pyTooling.Metaclasses.mustoverride`
+	   * :deco:`~pyTooling.MetaClasses.abstractmethod`
+	   * :deco:`~pyTooling.MetaClasses.mustoverride`
 	"""
 
 	def decorator(method: C) -> C:
@@ -168,7 +168,7 @@ class readonly(property):
 
 	.. seealso::
 
-	   :deco:`property`
+	   :class:`property`
 	     A decorator to convert getter, setter and deleter methods into a property applying the descriptor protocol.
 	"""
 

--- a/pyTooling/Decorators/__init__.py
+++ b/pyTooling/Decorators/__init__.py
@@ -156,18 +156,20 @@ def notimplemented(message: str) -> Callable:
 
 
 @export
-class ReadOnlyProperty(property):
+class readonly(property):
 	"""
-	A :class:`property` that rejects attaching a setter or a deleter.
+	Marks a property as *read-only*.
+
+	The doc-string is taken from the getter-method, like :class:`property` does.
 
 	A plain :class:`property` hands out ``<property>.setter`` and ``<property>.deleter``, so a property declared as
-	read-only could be made writable again further down the class body - and the declaration would silently become a
-	lie. Both methods therefore raise an :exc:`AttributeError` instead.
+	read-only could be made writable again further down the class body. Both methods therefore raise an
+	:exc:`AttributeError` instead.
 
 	.. seealso::
 
-	   :func:`~pyTooling.Decorators.readonly`
-	     The decorator creating a read-only property.
+	   :deco:`property`
+	     A decorator to convert getter, setter and deleter methods into a property applying the descriptor protocol.
 	"""
 
 	def setter(self, fset: Callable) -> NoReturn:
@@ -191,28 +193,6 @@ class ReadOnlyProperty(property):
 		ex = AttributeError(f"Property '{self.fget.__name__}' is read-only, so it can't have a deleter.")
 		ex.add_note(f"Use '@property' instead of '@readonly', if the property should be deletable.")
 		raise ex
-
-
-@export
-def readonly(func: Callable) -> ReadOnlyProperty:
-	"""
-	Marks a property as *read-only*.
-
-	The doc-string will be taken from the getter-function.
-
-	Using ``<property>.setter`` or ``<property>.deleter`` on the result raises an :exc:`AttributeError`.
-
-	:param func: Function to convert to a read-only property.
-	:returns:    A property object with just a getter.
-
-	.. seealso::
-
-	   :class:`property`
-	     A decorator to convert getter, setter and deleter methods into a property applying the descriptor protocol.
-	   :class:`~pyTooling.Decorators.ReadOnlyProperty`
-	     The property type returned by this decorator.
-	"""
-	return ReadOnlyProperty(fget=func, fset=None, fdel=None, doc=func.__doc__)
 
 
 @export

--- a/pyTooling/Dependency/Python.py
+++ b/pyTooling/Dependency/Python.py
@@ -59,9 +59,11 @@ except ImportError as ex:  # pragma: no cover
 
 from pyTooling.Decorators      import export, readonly
 from pyTooling.MetaClasses     import ExtendedType, abstractmethod
-from pyTooling.Exceptions      import ToolingException
 from pyTooling.Common          import getFullyQualifiedName, firstValue
 from pyTooling.Dependency      import Package, PackageStorage, PackageVersion, PackageDependencyGraph
+from pyTooling.Dependency      import BrokenRequirementWarning, NoSessionAvailableException, ProjectNotFoundException
+from pyTooling.Dependency      import ReleaseDetailsWarning, ReleaseNotFoundException
+from pyTooling.Warning         import WarningCollector
 from pyTooling.GenericPath.URL import URL
 from pyTooling.Versioning      import SemanticVersion, PythonVersion, Parts
 
@@ -245,16 +247,16 @@ class Release(PackageVersion, LazyLoadableMixin):
 
 	def DownloadDetails(self) -> None:
 		if self._session is None:
-			# TODO: NoSessionAvailableException
-			raise ToolingException(f"No session available.")
+			ex = NoSessionAvailableException(f"No session available to download release '{self._version}' of package '{self._package._name}'.")
+			ex.add_note(f"A session is opened by the package index and handed to the objects it creates.")
+			raise ex
 
 		response = self._session.get(url=f"{self._api}{self._GetPyPIEndpoint()}")
 		try:
 			response.raise_for_status()
 		except HTTPError as ex:
 			if ex.response.status_code == 404:
-				# TODO: ReleaseNotFoundException
-				raise ToolingException(f"Release '{self._version}' of package '{self._package._name}' not found.")
+				raise ReleaseNotFoundException(f"Release '{self._version}' of package '{self._package._name}' not found.") from ex
 
 		self.UpdateDetailsFromPyPIJSON(response.json())
 
@@ -286,8 +288,11 @@ class Release(PackageVersion, LazyLoadableMixin):
 				else:
 					brokenRequirements.append(req)
 
-			# TODO: raise a warning
 			if len(brokenRequirements) > 0:
+				WarningCollector.Raise(
+					BrokenRequirementWarning(f"Package '{self._package._name}' has {len(brokenRequirements)} requirement(s) whose marker matches no declared extra."),
+					notes=[f"Broken requirement: {req}" for req in brokenRequirements]
+				)
 				self._requirements[0] = brokenRequirements
 
 		self.__lazy_state__ = LazyLoaderState.FullyLoaded
@@ -382,16 +387,16 @@ class Project(Package, LazyLoadableMixin):
 
 	def DownloadDetails(self) -> None:
 		if self._session is None:
-			# TODO: NoSessionAvailableException
-			raise ToolingException(f"No session available.")
+			ex = NoSessionAvailableException(f"No session available to download details of package '{self._name}'.")
+			ex.add_note(f"A session is opened by the package index and handed to the objects it creates.")
+			raise ex
 
 		response = self._session.get(url=f"{self._api}{self._GetPyPIEndpoint()}")
 		try:
 			response.raise_for_status()
 		except HTTPError as ex:
 			if ex.response.status_code == 404:
-				# TODO: ReleaseNotFoundException
-				raise ToolingException(f"Package '{self._name}' not found.")
+				raise ProjectNotFoundException(f"Package '{self._name}' not found.") from ex
 
 		self.UpdateDetailsFromPyPIJSON(response.json())
 
@@ -455,9 +460,11 @@ class Project(Package, LazyLoadableMixin):
 					if isinstance(result, Exception):
 						delList.append((release, result))
 
-				# TODO: raise a warning
 				for release, ex in delList:
-					print(f"  Removing {release.Project._name} {release.Version} - {ex}")
+					WarningCollector.Raise(
+						ReleaseDetailsWarning(f"Dropping release '{release.Version}' of package '{release.Project._name}': details couldn't be downloaded."),
+						ex
+					)
 					del self.Releases[release.Version]
 
 		asyncio_run(ParallelDownloadReleaseDetails())

--- a/pyTooling/Dependency/__init__.py
+++ b/pyTooling/Dependency/__init__.py
@@ -43,6 +43,45 @@ from pyTooling.MetaClasses import ExtendedType
 from pyTooling.Exceptions  import ToolingException
 from pyTooling.Common      import getFullyQualifiedName, firstKey
 from pyTooling.Versioning  import SemanticVersion
+from pyTooling.Warning     import Warning
+
+
+@export
+class DependencyException(ToolingException):
+	"""Base-exception of all exceptions raised by :mod:`pyTooling.Dependency`."""
+
+
+@export
+class NoSessionAvailableException(DependencyException):
+	"""
+	The operation needs a session to the package index, but no session was opened.
+
+	A session is created by the package index and handed to the objects it creates.
+	"""
+
+
+@export
+class ProjectNotFoundException(DependencyException):
+	"""The package index doesn't know a project of that name."""
+
+
+@export
+class ReleaseNotFoundException(DependencyException):
+	"""The project exists in the package index, but not in the requested version."""
+
+
+@export
+class BrokenRequirementWarning(Warning):
+	"""
+	A requirement carries an environment marker that matches none of the extras declared by the project.
+
+	Such a requirement can't be assigned to an extra, so it's not reachable through :attr:`Requirements`.
+	"""
+
+
+@export
+class ReleaseDetailsWarning(Warning):
+	"""Downloading the details of a release failed, therefore the release was dropped from the project."""
 
 
 @export

--- a/pyTooling/Exceptions/__init__.py
+++ b/pyTooling/Exceptions/__init__.py
@@ -85,7 +85,7 @@ class OverloadResolutionError(Exception):
 
 	.. seealso::
 
-	   :func:`@overloadable <pyTooling.MetaClasses.overloadable>`
+	   :deco:`~pyTooling.MetaClasses.overloadable`
 	      |rarr| Mark a method as *overloadable*.
 	"""
 

--- a/pyTooling/GenericPath/URL.py
+++ b/pyTooling/GenericPath/URL.py
@@ -38,7 +38,7 @@ This package provides a representation for a Uniform Resource Locator (URL).
 
 from enum     import IntFlag
 from re       import compile as re_compile
-from typing   import Dict, Optional as Nullable, Mapping
+from typing   import ClassVar, Dict, Optional as Nullable, Mapping
 
 from pyTooling.Decorators  import export, readonly
 from pyTooling.Exceptions  import ToolingException
@@ -157,8 +157,8 @@ class Element(ElementMixIn):
 class Path(PathMixIn):
 	"""Represents a path in a URL."""
 
-	ELEMENT_DELIMITER = "/"   #: Delimiter symbol in URLs between path elements.
-	ROOT_DELIMITER =    "/"   #: Delimiter symbol in URLs between root element and first path element.
+	ELEMENT_DELIMITER: ClassVar[str] = "/"   #: Delimiter symbol in URLs between path elements.
+	ROOT_DELIMITER:    ClassVar[str] = "/"   #: Delimiter symbol in URLs between root element and first path element.
 
 	@classmethod
 	def Parse(cls, path: str, root: Nullable[Host] = None) -> "Path":

--- a/pyTooling/GenericPath/__init__.py
+++ b/pyTooling/GenericPath/__init__.py
@@ -29,7 +29,7 @@
 # ==================================================================================================================== #
 #
 """A generic path to derive domain specific path libraries."""
-from typing import List, Optional as Nullable, Type
+from typing import ClassVar, List, Optional as Nullable, Type
 
 from pyTooling.Decorators  import export
 from pyTooling.MetaClasses import ExtendedType
@@ -39,7 +39,7 @@ from pyTooling.MetaClasses import ExtendedType
 class Base(metaclass=ExtendedType, mixin=True):
 	"""Base-mixin-class for all :mod:`pyTooling.GenericPath` path elements."""
 
-	DELIMITER = "/"            #: Path element delimiter sign.
+	DELIMITER: ClassVar[str] = "/"            #: Path element delimiter sign.
 
 	_parent: Nullable["Base"]  #: Reference to the parent object.
 
@@ -88,8 +88,8 @@ class ElementMixIn(Base, mixin=True):
 class PathMixIn(metaclass=ExtendedType, mixin=True):
 	"""Mixin-class for a path."""
 
-	ELEMENT_DELIMITER = "/"          #: Path element delimiter sign.
-	ROOT_DELIMITER =    "/"          #: Root element delimiter sign.
+	ELEMENT_DELIMITER: ClassVar[str] = "/"          #: Path element delimiter sign.
+	ROOT_DELIMITER:    ClassVar[str] = "/"          #: Root element delimiter sign.
 
 	_isAbsolute: bool                #: True, if the path is absolute.
 	_elements:   List[ElementMixIn]  #: List of path elements.

--- a/pyTooling/Graph/GraphML.py
+++ b/pyTooling/Graph/GraphML.py
@@ -37,7 +37,7 @@ A data model to write out GraphML XML files.
 """
 from enum    import Enum, auto
 from pathlib import Path
-from typing  import Any, List, Dict, Union, Optional as Nullable
+from typing  import Any, ClassVar, List, Dict, Union, Optional as Nullable
 
 from pyTooling.Decorators  import export, readonly
 from pyTooling.MetaClasses import ExtendedType
@@ -492,11 +492,11 @@ class Subgraph(Node, BaseGraph):
 
 @export
 class GraphMLDocument(Base):
-	xmlNS = {
+	xmlNS: ClassVar[Dict[Nullable[str], str]] = {
 		None:  "http://graphml.graphdrawing.org/xmlns",
 		"xsi": "http://www.w3.org/2001/XMLSchema-instance"
 	}
-	xsi = {
+	xsi: ClassVar[Dict[str, str]] = {
 		"schemaLocation": "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd"
 	}
 

--- a/pyTooling/Graph/__init__.py
+++ b/pyTooling/Graph/__init__.py
@@ -175,6 +175,15 @@ class NotInSameGraph(GraphException):
 
 
 @export
+class NotInDifferentSubgraphs(GraphException):
+	"""
+	The exception is raised when creating a link between two vertices, but these are in the same subgraph.
+
+	A link crosses subgraph boundaries. Two vertices within one subgraph are connected by an edge.
+	"""
+
+
+@export
 class DuplicateVertexError(GraphException):
 	"""The exception is raised when the vertex already exists in the graph."""
 
@@ -834,8 +843,10 @@ class Vertex(
 				else:
 					raise DuplicateEdgeError(f"Edge ID '{edgeID}' already exists in this subgraph.")
 		else:
-			# FIXME: needs an error message
-			raise GraphException()
+			ex = NotInSameGraph(f"Vertex {self!r} and vertex {vertex!r} are not in the same graph or subgraph.")
+			ex.add_note(f"An edge can only connect vertices within the same graph or subgraph.")
+			ex.add_note(f"Use LinkToVertex or LinkFromVertex to connect vertices across subgraph boundaries.")
+			raise ex
 
 		return edge
 
@@ -896,8 +907,10 @@ class Vertex(
 				else:
 					raise DuplicateEdgeError(f"Edge ID '{edgeID}' already exists in this graph.")
 		else:
-			# FIXME: needs an error message
-			raise GraphException()
+			ex = NotInSameGraph(f"Vertex {self!r} and vertex {vertex!r} are not in the same graph or subgraph.")
+			ex.add_note(f"An edge can only connect vertices within the same graph or subgraph.")
+			ex.add_note(f"Use LinkToVertex or LinkFromVertex to connect vertices across subgraph boundaries.")
+			raise ex
 
 		return edge
 
@@ -966,8 +979,10 @@ class Vertex(
 				else:
 					raise DuplicateEdgeError(f"Edge ID '{edgeID}' already exists in this graph.")
 		else:
-			# FIXME: needs an error message
-			raise GraphException()
+			ex = NotInSameGraph(f"Vertex {self!r} and vertex {vertex!r} are not in the same graph or subgraph.")
+			ex.add_note(f"An edge can only connect vertices within the same graph or subgraph.")
+			ex.add_note(f"Use LinkToVertex or LinkFromVertex to connect vertices across subgraph boundaries.")
+			raise ex
 
 		return edge
 
@@ -1036,8 +1051,10 @@ class Vertex(
 				else:
 					raise DuplicateEdgeError(f"Edge ID '{edgeID}' already exists in this graph.")
 		else:
-			# FIXME: needs an error message
-			raise GraphException()
+			ex = NotInSameGraph(f"Vertex {self!r} and vertex {vertex!r} are not in the same graph or subgraph.")
+			ex.add_note(f"An edge can only connect vertices within the same graph or subgraph.")
+			ex.add_note(f"Use LinkToVertex or LinkFromVertex to connect vertices across subgraph boundaries.")
+			raise ex
 
 		return edge
 
@@ -1075,8 +1092,10 @@ class Vertex(
 		.. todo:: GRAPH::Vertex::LinkToVertex Needs possible exceptions to be documented.
 		"""
 		if self._subgraph is vertex._subgraph:
-			# FIXME: needs an error message
-			raise GraphException()
+			ex = NotInDifferentSubgraphs(f"Vertex {self!r} and vertex {vertex!r} are in the same subgraph.")
+			ex.add_note(f"A link can only connect vertices across subgraph boundaries.")
+			ex.add_note(f"Use EdgeToVertex or EdgeFromVertex to connect vertices within the same subgraph.")
+			raise ex
 		else:
 			link = Link(self, vertex, linkID, linkValue, linkWeight, keyValuePairs)
 
@@ -1139,8 +1158,10 @@ class Vertex(
 		.. todo:: GRAPH::Vertex::LinkFromVertex Needs possible exceptions to be documented.
 		"""
 		if self._subgraph is vertex._subgraph:
-			# FIXME: needs an error message
-			raise GraphException()
+			ex = NotInDifferentSubgraphs(f"Vertex {self!r} and vertex {vertex!r} are in the same subgraph.")
+			ex.add_note(f"A link can only connect vertices across subgraph boundaries.")
+			ex.add_note(f"Use EdgeToVertex or EdgeFromVertex to connect vertices within the same subgraph.")
+			raise ex
 		else:
 			link = Link(vertex, self, linkID, linkValue, linkWeight, keyValuePairs)
 

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -101,6 +101,14 @@ class DuplicateFieldInSlotsError(ExtendedTypeError):
 
 
 @export
+class IncompatibleMetaClassError(ExtendedTypeError):
+	"""
+	This exception is raised when a class decorated with :func:`slotted`, :func:`mixin` or :func:`singleton` uses a
+	meta-class that is neither :class:`type` nor derived from :class:`~pyTooling.MetaClasses.ExtendedType`.
+	"""
+
+
+@export
 class AbstractClassError(ExtendedTypeError):
 	"""
 	This exception is raised, when a class contains methods marked with *abstractmethod* or *must-override*.
@@ -144,8 +152,17 @@ class MustOverrideClassError(AbstractClassError):
 M = TypeVar("M", bound=Callable)   #: A type variable for methods.
 
 
-@export
-def slotted(cls):
+def _recreateClass(cls: type, decoratorName: str, **options: bool) -> type:
+	"""
+	Recreate a class with :class:`ExtendedType` (or the class' own compatible meta-class) applying the given options.
+
+	:param cls:                         Class to recreate.
+	:param decoratorName:               Name of the calling decorator. It's used in the error message.
+	:param options:                     Meta-class options like ``slots``, ``mixin`` or ``singleton``.
+	:returns:                           The recreated class.
+	:raises IncompatibleMetaClassError: If the class' meta-class is neither :class:`type`, nor derived from
+	                                    :class:`ExtendedType`.
+	"""
 	if cls.__class__ is type:
 		metacls = ExtendedType
 	elif issubclass(cls.__class__, ExtendedType):
@@ -153,7 +170,11 @@ def slotted(cls):
 		for method in cls.__methods__:
 			delattr(method, "__classobj__")
 	else:
-		raise ExtendedTypeError("Class uses an incompatible meta-class.")  # FIXME: create exception for it?
+		metaClass = cls.__class__
+		ex = IncompatibleMetaClassError(f"Class '{cls.__name__}' decorated with '@{decoratorName}' uses an incompatible meta-class.")
+		ex.add_note(f"Meta-class is '{metaClass.__module__}.{metaClass.__name__}'.")
+		ex.add_note(f"A decorated class must use 'type' or a meta-class derived from 'pyTooling.MetaClasses.ExtendedType'.")
+		raise ex
 
 	bases = tuple(base for base in cls.__bases__ if base is not object)
 	slots = cls.__dict__["__slots__"] if "__slots__" in cls.__dict__ else tuple()
@@ -164,53 +185,22 @@ def slotted(cls):
 		if key not in slots:
 			members[key] = value
 
-	return metacls(cls.__name__, bases, members, slots=True)
+	return metacls(cls.__name__, bases, members, **options)
+
+
+@export
+def slotted(cls):
+	return _recreateClass(cls, "slotted", slots=True)
 
 
 @export
 def mixin(cls):
-	if cls.__class__ is type:
-		metacls = ExtendedType
-	elif issubclass(cls.__class__, ExtendedType):
-		metacls = cls.__class__
-		for method in cls.__methods__:
-			delattr(method, "__classobj__")
-	else:
-		raise ExtendedTypeError("Class uses an incompatible meta-class.")  # FIXME: create exception for it?
-
-	bases = tuple(base for base in cls.__bases__ if base is not object)
-	slots = cls.__dict__["__slots__"] if "__slots__" in cls.__dict__ else tuple()
-	members = {
-		"__qualname__": cls.__qualname__
-	}
-	for key, value in cls.__dict__.items():
-		if key not in slots:
-			members[key] = value
-
-	return metacls(cls.__name__, bases, members, mixin=True)
+	return _recreateClass(cls, "mixin", mixin=True)
 
 
 @export
 def singleton(cls):
-	if cls.__class__ is type:
-		metacls = ExtendedType
-	elif issubclass(cls.__class__, ExtendedType):
-		metacls = cls.__class__
-		for method in cls.__methods__:
-			delattr(method, "__classobj__")
-	else:
-		raise ExtendedTypeError("Class uses an incompatible meta-class.")  # FIXME: create exception for it?
-
-	bases = tuple(base for base in cls.__bases__ if base is not object)
-	slots = cls.__dict__["__slots__"] if "__slots__" in cls.__dict__ else tuple()
-	members = {
-		"__qualname__": cls.__qualname__
-	}
-	for key, value in cls.__dict__.items():
-		if key not in slots:
-			members[key] = value
-
-	return metacls(cls.__name__, bases, members, singleton=True)
+	return _recreateClass(cls, "singleton", singleton=True)
 
 
 @export
@@ -665,6 +655,40 @@ class ExtendedType(type):
 		return methods, methodsWithAttributes
 
 	@classmethod
+	def _getAnnotations(metacls, members: Dict[str, Any]) -> Dict[str, Any]:
+		"""
+		Return the type annotations declared in a class body.
+
+		Python 3.14 (:pep:`649`) no longer fills ``__annotations__`` while the class body is executed, but installs an
+		``__annotate_func__`` instead. The :mod:`annotationlib` module needed to evaluate that function doesn't exist on
+		older Python versions, therefore both mechanisms are supported.
+
+		:param members: Dictionary of class members.
+		:returns:       Dictionary of annotated field names and their type annotations. Empty, if the class body declared
+		                no annotations.
+		"""
+		if "__annotations__" in members:
+			# WORKAROUND: LEGACY SUPPORT Python <= 3.13
+			#   Accessing annotations was changed in Python 3.14.
+			#   The necessary 'annotationlib' is not available for older Python versions.
+			return members["__annotations__"]
+		elif version_info >= (3, 14) and (annotate := members.get("__annotate_func__", None)) is not None:
+			from annotationlib import Format
+			return annotate(Format.VALUE)
+		else:
+			return {}
+
+	@classmethod
+	def _isClassVariable(metacls, typeAnnotation: Any) -> bool:
+		"""
+		Check if a type annotation declares a class variable.
+
+		:param typeAnnotation: The type annotation to check.
+		:returns:              ``True``, if the annotation is a :class:`~typing.ClassVar`.
+		"""
+		return isinstance(typeAnnotation, _GenericAlias) and typeAnnotation.__origin__ is ClassVar
+
+	@classmethod
 	def _computeSlots(
 		self,
 		className:   str,
@@ -703,7 +727,7 @@ class ExtendedType(type):
 					ex.add_note(f"All base-classes of a class using '__slots__' must use '__slots__' itself.")
 					raise ex
 
-			# FIXME: should have a check for non-empty slots on secondary base-classes too
+			# Non-empty __slots__ on secondary base-classes are rejected by _aggregateMixinSlots below.
 
 			# Copy all field names from primary base-class' __slots__, which are later needed for error checking.
 			inheritedSlottedFields = {}
@@ -717,16 +741,7 @@ class ExtendedType(type):
 						inheritedSlottedFields[annotation] = base
 
 			# When adding annotated fields to slottedFields, check if name was not used in inheritance hierarchy.
-			if "__annotations__" in members:
-				# WORKAROUND: LEGACY SUPPORT Python <= 3.13
-				#   Accessing annotations was changed in Python 3.14.
-				#   The necessary 'annotationlib' is not available for older Python versions.
-				annotations: Dict[str, Any] = members.get("__annotations__", {})
-			elif version_info >= (3, 14) and (annotate := members.get("__annotate_func__", None)) is not None:
-				from annotationlib import Format
-				annotations: Dict[str, Any] = annotate(Format.VALUE)
-			else:
-				annotations = {}
+			annotations: Dict[str, Any] = self._getAnnotations(members)
 
 			for fieldName, typeAnnotation in annotations.items():
 				if fieldName in inheritedSlottedFields:
@@ -736,7 +751,7 @@ class ExtendedType(type):
 				# A ClassVar is never a slot, with or without an initial value.
 				# * If it has an initial value, copy field and initial value to classFields dictionary and remove field from members.
 				# * Otherwise it's a forward declaration and derived classes assign the actual value.
-				isClassVariable = isinstance(typeAnnotation, _GenericAlias) and typeAnnotation.__origin__ is ClassVar
+				isClassVariable = self._isClassVariable(typeAnnotation)
 				hasInitialValue = fieldName in members
 				if isClassVariable:
 					if hasInitialValue:
@@ -754,18 +769,31 @@ class ExtendedType(type):
 					slottedFields.append(fieldName)
 
 			mixinSlots = self._aggregateMixinSlots(className, baseClasses)
+
+			# A member assigned in the class body without a type annotation stays a class attribute. If it carries the name
+			# of a slot, that class attribute shadows the slot's descriptor and the field becomes read-only on instances.
+			# Report it here instead of letting the first assignment fail with a bare AttributeError.
+			shadowedSlots = {**inheritedSlottedFields, **{fieldName: None for fieldName in mixinSlots}}
+			for fieldName in shadowedSlots.keys() & members.keys():
+				ex = DuplicateFieldInSlotsError(f"Slot '{fieldName}' is shadowed by a class member in class '{className}'.")
+				if (baseClass := shadowedSlots[fieldName]) is not None:
+					ex.add_note(f"Slot '{fieldName}' is declared in base-class '{baseClass.__module__}.{baseClass.__name__}'.")
+				else:
+					ex.add_note(f"Slot '{fieldName}' is contributed by a mixin-class.")
+				ex.add_note(f"An assignment without a type annotation creates a class attribute, which hides the slot's descriptor.")
+				ex.add_note(f"Annotate it as 'ClassVar[...]' to declare a class variable, or remove the assignment.")
+				raise ex
 		else:
 			# When adding annotated fields to slottedFields, check if name was not used in inheritance hierarchy.
-			annotations: Dict[str, Any] = members.get("__annotations__", {})
+			annotations: Dict[str, Any] = self._getAnnotations(members)
 			for fieldName, typeAnnotation in annotations.items():
 				# If annotated field is a ClassVar, and it has an initial value
 				# * copy field and initial value to classFields dictionary
 				# * remove field from members
-				if isinstance(typeAnnotation, _GenericAlias) and typeAnnotation.__origin__ is ClassVar and fieldName in members:
+				if self._isClassVariable(typeAnnotation) and fieldName in members:
 					classFields[fieldName] = members[fieldName]
 					del members[fieldName]
 
-		# FIXME: search for fields without annotation
 		if mixin:
 			mixinSlots.extend(slottedFields)
 			members["__slotted__"] = True

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -126,9 +126,9 @@ class AbstractClassError(ExtendedTypeError):
 
 	.. seealso::
 
-	   :func:`@abstractmethod <pyTooling.MetaClasses.abstractmethod>`
+	   :deco:`~pyTooling.MetaClasses.abstractmethod`
 	      |rarr| Mark a method as *abstract*.
-	   :func:`@mustoverride <pyTooling.MetaClasses.mustoverride>`
+	   :deco:`~pyTooling.MetaClasses.mustoverride`
 	      |rarr| Mark a method as *must overrride*.
 	   :exc:`~MustOverrideClassError`
 	      |rarr| Exception raised, if a method is marked as *must-override*.
@@ -142,9 +142,9 @@ class MustOverrideClassError(AbstractClassError):
 
 	.. seealso::
 
-	   :func:`@abstractmethod <pyTooling.MetaClasses.abstractmethod>`
+	   :deco:`~pyTooling.MetaClasses.abstractmethod`
 	      |rarr| Mark a method as *abstract*.
-	   :func:`@mustoverride <pyTooling.MetaClasses.mustoverride>`
+	   :deco:`~pyTooling.MetaClasses.mustoverride`
 	      |rarr| Mark a method as *must overrride*.
 	   :exc:`~AbstractClassError`
 	      |rarr| Exception raised, if a method is marked as *abstract*.
@@ -243,8 +243,8 @@ def abstractmethod(method: M) -> M:
 	.. seealso::
 
 	   * :exc:`~pyTooling.Exceptions.AbstractClassError`
-	   * :func:`~pyTooling.Metaclasses.mustoverride`
-	   * :func:`~pyTooling.Metaclasses.notimplemented`
+	   * :deco:`~pyTooling.MetaClasses.mustoverride`
+	   * :deco:`~pyTooling.Decorators.notimplemented`
 	"""
 	@wraps(method)
 	def func(self) -> NoReturn:
@@ -286,8 +286,8 @@ def mustoverride(method: M) -> M:
 	.. seealso::
 
 	   * :exc:`~pyTooling.Exceptions.MustOverrideClassError`
-	   * :func:`~pyTooling.Metaclasses.abstractmethod`
-	   * :func:`~pyTooling.Metaclasses.notimplemented`
+	   * :deco:`~pyTooling.MetaClasses.abstractmethod`
+	   * :deco:`~pyTooling.Decorators.notimplemented`
 	"""
 	method.__mustOverride__ = True
 	return method

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -40,12 +40,13 @@ from functools  import wraps
 from itertools  import chain
 from sys        import version_info
 from threading  import Condition
-from types      import FunctionType, MethodType
+from types      import BuiltinFunctionType, FunctionType, MethodType
 from typing     import Any, Tuple, List, Dict, Callable, Generator, Set, Iterator, Iterable, Union, NoReturn, Self
 from typing     import Type, TypeVar, Generic, _GenericAlias, ClassVar, Optional as Nullable
 
 from pyTooling.Exceptions import ToolingException
 from pyTooling.Decorators import export, readonly
+from pyTooling.Warning    import Warning, WarningCollector
 
 
 __all__ = ["M"]
@@ -101,9 +102,19 @@ class DuplicateFieldInSlotsError(ExtendedTypeError):
 
 
 @export
+class UnannotatedFieldWarning(Warning):
+	"""
+	A class declares a field that was assigned in the class body without a type annotation.
+
+	An object field is annotated with its type, a class variable with :class:`~typing.ClassVar`. Without an annotation,
+	:class:`ExtendedType` can't tell the two apart, and the field never becomes a slot.
+	"""
+
+
+@export
 class IncompatibleMetaClassError(ExtendedTypeError):
 	"""
-	This exception is raised when a class decorated with :func:`slotted`, :func:`mixin` or :func:`singleton` uses a
+	This exception is raised when a class decorated with :deco:`slotted`, :deco:`mixin` or :deco:`singleton` uses a
 	meta-class that is neither :class:`type` nor derived from :class:`~pyTooling.MetaClasses.ExtendedType`.
 	"""
 
@@ -659,9 +670,11 @@ class ExtendedType(type):
 		"""
 		Return the type annotations declared in a class body.
 
-		Python 3.14 (:pep:`649`) no longer fills ``__annotations__`` while the class body is executed, but installs an
-		``__annotate_func__`` instead. The :mod:`annotationlib` module needed to evaluate that function doesn't exist on
-		older Python versions, therefore both mechanisms are supported.
+		.. important::
+
+		   Python 3.14 (:pep:`649`) no longer fills ``__annotations__`` while the class body is executed, but installs an
+		   ``__annotate_func__`` instead. The :mod:`annotationlib` module needed to evaluate that function doesn't exist on
+		   older Python versions, therefore both mechanisms are supported.
 
 		:param members: Dictionary of class members.
 		:returns:       Dictionary of annotated field names and their type annotations. Empty, if the class body declared
@@ -687,6 +700,60 @@ class ExtendedType(type):
 		:returns:              ``True``, if the annotation is a :class:`~typing.ClassVar`.
 		"""
 		return isinstance(typeAnnotation, _GenericAlias) and typeAnnotation.__origin__ is ClassVar
+
+	@classmethod
+	def _isField(metacls, member: Any) -> bool:
+		"""
+		Check if a class member is a field, so a type annotation is expected for it.
+
+		Methods, nested classes, properties and any other descriptor carry their type information in their signature or
+		in their own declaration, therefore they aren't fields.
+
+		:param member: The class member to check.
+		:returns:      ``True``, if the member is a field.
+		"""
+		if isinstance(member, (FunctionType, MethodType, BuiltinFunctionType, classmethod, staticmethod, property, type)):
+			return False
+
+		# Any descriptor (e.g. a custom property implementation) declares its own type information.
+		return not (hasattr(member, "__get__") or hasattr(member, "__set__"))
+
+	@classmethod
+	def _checkForUnannotatedFields(metacls, className: str, members: Dict[str, Any], annotations: Dict[str, Any]) -> None:
+		"""
+		Report fields that were assigned in the class body without a type annotation.
+
+		Every field should carry type information: an object field is annotated with its type, a class variable with
+		``ClassVar[...]``. Without an annotation, :class:`ExtendedType` can't tell the two apart - an un-annotated
+		assignment never becomes a slot and silently stays a class attribute.
+
+		.. important::
+
+		   This is reported as a :class:`~pyTooling.Warning.Warning`, so it needs a
+		   :class:`~pyTooling.Warning.WarningCollector` somewhere up the call-hierarchy to be observed. Importing a module
+		   with un-annotated fields doesn't fail.
+
+		:param className:   The name of the class to construct.
+		:param members:     Dictionary of class members.
+		:param annotations: Dictionary of annotated field names and their type annotations.
+		"""
+		unannotatedFields = [
+			fieldName
+			for fieldName, member in members.items()
+			if not (fieldName.startswith("__") and fieldName.endswith("__"))
+				and fieldName not in annotations
+				and metacls._isField(member)
+		]
+
+		if len(unannotatedFields) > 0:
+			fieldNames = "', '".join(unannotatedFields)
+			WarningCollector.Raise(
+				UnannotatedFieldWarning(f"Class '{className}' declares {len(unannotatedFields)} field(s) without a type annotation."),
+				notes=(
+					f"Field(s) without a type annotation: '{fieldNames}'.",
+					f"Annotate a class variable as 'ClassVar[...]' and an object field with its type.",
+				)
+			)
 
 	@classmethod
 	def _computeSlots(
@@ -715,6 +782,7 @@ class ExtendedType(type):
 		slottedFields = []
 		classFields =   {}
 		objectFields =  {}
+		annotations: Dict[str, Any] = self._getAnnotations(members)
 		if slots or mixin:
 			# If slots are used, all base classes must use __slots__.
 			for baseClass in self._iterateBaseClasses(baseClasses):
@@ -741,8 +809,6 @@ class ExtendedType(type):
 						inheritedSlottedFields[annotation] = base
 
 			# When adding annotated fields to slottedFields, check if name was not used in inheritance hierarchy.
-			annotations: Dict[str, Any] = self._getAnnotations(members)
-
 			for fieldName, typeAnnotation in annotations.items():
 				if fieldName in inheritedSlottedFields:
 					cls = inheritedSlottedFields[fieldName]
@@ -785,7 +851,6 @@ class ExtendedType(type):
 				raise ex
 		else:
 			# When adding annotated fields to slottedFields, check if name was not used in inheritance hierarchy.
-			annotations: Dict[str, Any] = self._getAnnotations(members)
 			for fieldName, typeAnnotation in annotations.items():
 				# If annotated field is a ClassVar, and it has an initial value
 				# * copy field and initial value to classFields dictionary
@@ -793,6 +858,8 @@ class ExtendedType(type):
 				if self._isClassVariable(typeAnnotation) and fieldName in members:
 					classFields[fieldName] = members[fieldName]
 					del members[fieldName]
+
+		self._checkForUnannotatedFields(className, members, annotations)
 
 		if mixin:
 			mixinSlots.extend(slottedFields)

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -751,7 +751,7 @@ class ExtendedType(type):
 				UnannotatedFieldWarning(f"Class '{className}' declares {len(unannotatedFields)} field(s) without a type annotation."),
 				notes=(
 					f"Field(s) without a type annotation: '{fieldNames}'.",
-					f"Annotate a class variable as 'ClassVar[...]' and an object field with its type.",
+					f"Annotate a class variable as 'ClassVar[...]' or an object field with its type.",
 				)
 			)
 

--- a/pyTooling/TerminalUI/__init__.py
+++ b/pyTooling/TerminalUI/__init__.py
@@ -70,7 +70,7 @@ class TerminalBaseApplication(metaclass=ExtendedType, slots=True, singleton=True
 
 	try:
 		from colorama import Fore as Foreground
-		Foreground = {
+		Foreground: ClassVar[Dict[str, str]] = {
 			"RED":          Foreground.LIGHTRED_EX,
 			"DARK_RED":		  Foreground.RED,
 			"GREEN":        Foreground.LIGHTGREEN_EX,
@@ -92,7 +92,7 @@ class TerminalBaseApplication(metaclass=ExtendedType, slots=True, singleton=True
 			"WARNING":      Foreground.LIGHTYELLOW_EX
 		}                 #: Terminal colors
 	except ImportError:  # pragma: no cover
-		Foreground = {
+		Foreground: ClassVar[Dict[str, str]] = {
 			"RED":         "",
 			"DARK_RED":    "",
 			"GREEN":       "",
@@ -643,7 +643,7 @@ class Line(metaclass=ExtendedType, slots=True):
 	Represents a single message line with a severity and indentation level.
 	"""
 
-	_LOG_MESSAGE_FORMAT__ = {
+	_LOG_MESSAGE_FORMAT__: ClassVar[Dict[Severity, str]] = {
 		Severity.Exception:     "EXCEPTION: {message}",
 		Severity.ExceptionNote: "           > {message}",
 		Severity.Fatal:         "FATAL: {message}",
@@ -839,7 +839,7 @@ class TerminalApplication(TerminalBaseApplication):  #, ILineTerminal):
 	"""
 	A base-class for implementation of terminal applications emitting line-by-line messages.
 	"""
-	_LOG_MESSAGE_FORMAT__ = {
+	_LOG_MESSAGE_FORMAT__: ClassVar[Dict[Severity, str]] = {
 		Severity.Exception:            "{RED}[EXCEPTION] {message}{NOCOLOR}",
 		Severity.ExceptionNote:   "{DARK_RED}            > {message}{NOCOLOR}",
 		Severity.Fatal:           "{DARK_RED}[FATAL]     {message}{NOCOLOR}",

--- a/pyTooling/Versioning/__init__.py
+++ b/pyTooling/Versioning/__init__.py
@@ -1316,7 +1316,10 @@ class SemanticVersion(Version):
 		"""
 		Return a normalized string representation of this version number.
 
-		A prefix doesn't contribute to the version number's value, therefore it's not part of the normalized form.
+		.. note::
+
+		   A prefix doesn't contribute to the version number's value, therefore it's not part of the normalized form. Use
+		   :meth:`__str__` to render a version number including its prefix.
 
 		:returns: Raw version number representation without a prefix.
 		"""
@@ -1704,7 +1707,10 @@ class CalendarVersion(Version):
 		"""
 		Return a normalized string representation of this version number.
 
-		A prefix doesn't contribute to the version number's value, therefore it's not part of the normalized form.
+		.. note::
+
+		   A prefix doesn't contribute to the version number's value, therefore it's not part of the normalized form. Use
+		   :meth:`__str__` to render a version number including its prefix.
 
 		:returns: Raw version number representation without a prefix.
 		"""

--- a/pyTooling/Versioning/__init__.py
+++ b/pyTooling/Versioning/__init__.py
@@ -1966,7 +1966,7 @@ class VersionRange(Generic[V], metaclass=ExtendedType, slots=True):
 
 		self._lowerBound = value
 
-	@readonly
+	@property
 	def UpperBound(self) -> V:
 		"""
 		Property to access the range's upper bound.
@@ -1984,7 +1984,7 @@ class VersionRange(Generic[V], metaclass=ExtendedType, slots=True):
 
 		self._upperBound = value
 
-	@readonly
+	@property
 	def BoundHandling(self) -> RangeBoundHandling:
 		"""
 		Property to access the range's bound handling strategy.

--- a/pyTooling/Versioning/__init__.py
+++ b/pyTooling/Versioning/__init__.py
@@ -37,7 +37,7 @@ Implementation of semantic and date versioning version-numbers.
 """
 from collections.abc import Iterable as abc_Iterable
 from enum            import Flag, Enum
-from re              import compile as re_compile
+from re              import compile as re_compile, Pattern
 from typing          import Optional as Nullable, Union, Callable, Any, ClassVar, Generic, TypeVar, Iterable, Iterator, List
 
 from pyTooling.Decorators  import export, readonly
@@ -998,7 +998,7 @@ class Version(metaclass=ExtendedType, slots=True):
 class SemanticVersion(Version):
 	"""Representation of a semantic version number like ``3.7.12``."""
 
-	_PATTERN = re_compile(
+	_PATTERN: ClassVar[Pattern] = re_compile(
 		r"^"
 		r"(?P<prefix>[a-zA-Z]*)"
 		r"(?P<major>\d+)"
@@ -1310,11 +1310,13 @@ class SemanticVersion(Version):
 
 	def __repr__(self) -> str:
 		"""
-		Return a string representation of this version number without prefix ``v``.
+		Return a normalized string representation of this version number.
+
+		A prefix doesn't contribute to the version number's value, therefore it's not part of the normalized form.
 
 		:returns: Raw version number representation without a prefix.
 		"""
-		return f"{self._prefix if Parts.Prefix in self._parts else ''}{self._major}.{self._minor}.{self._micro}"
+		return f"{self._major}.{self._minor}.{self._micro}"
 
 	def __str__(self) -> str:
 		"""
@@ -1410,9 +1412,9 @@ class CalendarVersion(Version):
 
 	_PARTCOUNT: ClassVar[int] = 3   #: Number of numeric parts a version number of this class can carry.
 
-	_PATTERN = re_compile(
+	_PATTERN: ClassVar[Pattern] = re_compile(
 		r"^"
-		r"(?P<prefix>[a-zA-Z]*)"
+		r"(?P<prefix>rev|REV|[vViIrR])?"
 		r"(?P<major>\d+)"
 		r"(?:\.(?P<minor>\d+))?"
 		r"(?:\.(?P<micro>\d+))?"
@@ -1489,7 +1491,7 @@ class CalendarVersion(Version):
 		if (match := cls._PATTERN.match(versionString)) is None:
 			ex = ValueError(f"Syntax error in parameter 'versionString': '{versionString}'")
 			ex.add_note(f"A calendar version number is made of up to {cls._PARTCOUNT} numeric parts, e.g. '2024.04'.")
-			ex.add_note(f"It may carry an alphabetic prefix, e.g. 'v2024.04'.")
+			ex.add_note(f"It may carry one of the prefixes 'v', 'i', 'r' or 'rev', e.g. 'v2024.04'.")
 			raise ex
 
 		prefix = match["prefix"]
@@ -1696,12 +1698,13 @@ class CalendarVersion(Version):
 
 	def __repr__(self) -> str:
 		"""
-		Return a string representation of this version number.
+		Return a normalized string representation of this version number.
 
-		:returns: Version number representation including a prefix.
+		A prefix doesn't contribute to the version number's value, therefore it's not part of the normalized form.
+
+		:returns: Raw version number representation without a prefix.
 		"""
-		result = self._prefix if Parts.Prefix in self._parts else ""
-		result += f"{self._major}.{self._minor}"
+		result = f"{self._major}.{self._minor}"
 		result += f".{self._micro}" if Parts.Micro in self._parts else ""
 
 		return result

--- a/pyTooling/Versioning/__init__.py
+++ b/pyTooling/Versioning/__init__.py
@@ -38,7 +38,7 @@ Implementation of semantic and date versioning version-numbers.
 from collections.abc import Iterable as abc_Iterable
 from enum            import Flag, Enum
 from re              import compile as re_compile
-from typing          import Optional as Nullable, Union, Callable, Any, Generic, TypeVar, Iterable, Iterator, List
+from typing          import Optional as Nullable, Union, Callable, Any, ClassVar, Generic, TypeVar, Iterable, Iterator, List
 
 from pyTooling.Decorators  import export, readonly
 from pyTooling.MetaClasses import ExtendedType, abstractmethod, mustoverride
@@ -1408,11 +1408,14 @@ class PythonVersion(SemanticVersion):
 class CalendarVersion(Version):
 	"""Representation of a calendar version number like ``2021.10``."""
 
+	_PARTCOUNT: ClassVar[int] = 3   #: Number of numeric parts a version number of this class can carry.
+
 	_PATTERN = re_compile(
 		r"^"
 		r"(?P<prefix>[a-zA-Z]*)"
 		r"(?P<major>\d+)"
 		r"(?:\.(?P<minor>\d+))?"
+		r"(?:\.(?P<micro>\d+))?"
 		r"$"
 	)
 
@@ -1461,6 +1464,10 @@ class CalendarVersion(Version):
 		* ``r|R`` - release, revision
 		* ``rev|REV`` - revision
 
+		A version number carries up to :attr:`_PARTCOUNT` numeric parts. :class:`YearMonthVersion`,
+		:class:`YearWeekVersion` and :class:`YearReleaseVersion` describe two parts, so a third part is rejected for
+		them.
+
 		:param versionString: The version string to parse.
 		:param validator:     Optional, a validation function.
 		:returns:             An object representing a calendar version.
@@ -1468,6 +1475,7 @@ class CalendarVersion(Version):
 		:raises ValueError:   If parameter ``versionString`` is None.
 		:raises ValueError:   If parameter ``versionString`` is empty.
 		:raises ValueError:   If parameter ``versionString`` isn't a calendar version number.
+		:raises ValueError:   If parameter ``versionString`` has more parts than the class describes.
 		"""
 		if versionString is None:
 			raise ValueError("Parameter 'versionString' is None.")
@@ -1480,19 +1488,24 @@ class CalendarVersion(Version):
 
 		if (match := cls._PATTERN.match(versionString)) is None:
 			ex = ValueError(f"Syntax error in parameter 'versionString': '{versionString}'")
-			ex.add_note(f"A calendar version number is made of a major and an optional minor part, e.g. '2024.04'.")
+			ex.add_note(f"A calendar version number is made of up to {cls._PARTCOUNT} numeric parts, e.g. '2024.04'.")
 			ex.add_note(f"It may carry an alphabetic prefix, e.g. 'v2024.04'.")
 			raise ex
 
 		prefix = match["prefix"]
 		minor = match["minor"]
+		micro = match["micro"]
 
-		version = cls(
-			int(match["major"]),
-			0 if minor is None else int(minor),
-			flags=Flags.Clean,
-			prefix=prefix if prefix != "" else None
-		)
+		if micro is not None and cls._PARTCOUNT < 3:
+			ex = ValueError(f"Version number '{versionString}' has 3 parts, but '{cls.__name__}' describes {cls._PARTCOUNT}.")
+			ex.add_note(f"Use 'CalendarVersion' or 'YearMonthDayVersion' to parse a 3-part calendar version number.")
+			raise ex
+
+		numbers = [int(match["major"]), 0 if minor is None else int(minor)]
+		if micro is not None:
+			numbers.append(int(micro))
+
+		version = cls(*numbers, flags=Flags.Clean, prefix=prefix if prefix != "" else None)
 
 		if validator is not None and not validator(version):
 			raise ValueError(f"Failed to validate version string '{versionString}'.")  # pragma: no cover
@@ -1664,6 +1677,7 @@ class CalendarVersion(Version):
 
 		   * ``%M`` - major number (year)
 		   * ``%m`` - minor number (month/week)
+		   * ``%u`` - micro number (day)
 
 		:param formatSpec: The format specification.
 		:return:           Formatted version number.
@@ -1675,17 +1689,22 @@ class CalendarVersion(Version):
 		# result = result.replace("%P", str(self._prefix))
 		result = result.replace("%M", str(self._major))
 		result = result.replace("%m", str(self._minor))
+		result = result.replace("%u", str(self._micro))
 		# result = result.replace("%p", str(self._pre))
 
 		return result.replace("%%", "%")
 
 	def __repr__(self) -> str:
 		"""
-		Return a string representation of this version number with all parts.
+		Return a string representation of this version number.
 
 		:returns: Version number representation including a prefix.
 		"""
-		return f"{self._prefix if Parts.Prefix in self._parts else ''}{self._major}.{self._minor}"
+		result = self._prefix if Parts.Prefix in self._parts else ""
+		result += f"{self._major}.{self._minor}"
+		result += f".{self._micro}" if Parts.Micro in self._parts else ""
+
+		return result
 
 	def __str__(self) -> str:
 		"""
@@ -1696,6 +1715,7 @@ class CalendarVersion(Version):
 		result = self._prefix if Parts.Prefix in self._parts else ""
 		result += f"{self._major}"
 		result += f".{self._minor}" if Parts.Minor in self._parts else ""
+		result += f".{self._micro}" if Parts.Micro in self._parts else ""
 
 		return result
 
@@ -1703,6 +1723,8 @@ class CalendarVersion(Version):
 @export
 class YearMonthVersion(CalendarVersion):
 	"""Representation of a calendar version number made of year and month like ``2021.10``."""
+
+	_PARTCOUNT: ClassVar[int] = 2   #: A version number of this class carries year and month.
 
 	def __init__(
 		self,
@@ -1752,6 +1774,8 @@ class YearMonthVersion(CalendarVersion):
 class YearWeekVersion(CalendarVersion):
 	"""Representation of a calendar version number made of year and week like ``2021.47``."""
 
+	_PARTCOUNT: ClassVar[int] = 2   #: A version number of this class carries year and week.
+
 	def __init__(
 		self,
 		year: int,
@@ -1799,6 +1823,8 @@ class YearWeekVersion(CalendarVersion):
 @export
 class YearReleaseVersion(CalendarVersion):
 	"""Representation of a calendar version number made of year and release per year like ``2021.2``."""
+
+	_PARTCOUNT: ClassVar[int] = 2   #: A version number of this class carries year and release.
 
 	def __init__(
 		self,

--- a/pyTooling/Versioning/__init__.py
+++ b/pyTooling/Versioning/__init__.py
@@ -1000,7 +1000,7 @@ class SemanticVersion(Version):
 
 	_PATTERN: ClassVar[Pattern] = re_compile(
 		r"^"
-		r"(?P<prefix>[a-zA-Z]*)"
+		r"(?P<prefix>rev|REV|[vViIrR])?"
 		r"(?P<major>\d+)"
 		r"(?:\.(?P<minor>\d+))?"
 		r"(?:\.(?P<micro>\d+))?"
@@ -1096,7 +1096,9 @@ class SemanticVersion(Version):
 			raise ValueError("Parameter 'versionString' is empty.")
 
 		if (match := cls._PATTERN.match(versionString)) is None:
-			raise ValueError(f"Syntax error in parameter 'versionString': '{versionString}'")
+			ex = ValueError(f"Syntax error in parameter 'versionString': '{versionString}'")
+			ex.add_note(f"It may carry one of the prefixes 'v', 'i', 'r' or 'rev', e.g. 'v1.2.3'.")
+			raise ex
 
 		def toInt(value: Nullable[str]) -> Nullable[int]:
 			if value is None or value == "":
@@ -1106,6 +1108,8 @@ class SemanticVersion(Version):
 				return int(value)
 			except ValueError as ex:  # pragma: no cover
 				raise ValueError(f"Invalid part '{value}' in version number '{versionString}'.") from ex
+
+		prefix = match["prefix"]
 
 		release = match["release"]
 		if release is not None:
@@ -1142,7 +1146,7 @@ class SemanticVersion(Version):
 			dev=toInt(match["dev"]),
 			build=toInt(match["build"]),
 			postfix=match["postfix"],
-			prefix=match["prefix"],
+			prefix=prefix if prefix != "" else None,
 			# hash=match["hash"],
 			flags=Flags.Clean
 		)

--- a/pyTooling/Versioning/__init__.py
+++ b/pyTooling/Versioning/__init__.py
@@ -1408,6 +1408,14 @@ class PythonVersion(SemanticVersion):
 class CalendarVersion(Version):
 	"""Representation of a calendar version number like ``2021.10``."""
 
+	_PATTERN = re_compile(
+		r"^"
+		r"(?P<prefix>[a-zA-Z]*)"
+		r"(?P<major>\d+)"
+		r"(?:\.(?P<minor>\d+))?"
+		r"$"
+	)
+
 	def __init__(
 		self,
 		major: int,
@@ -1446,36 +1454,46 @@ class CalendarVersion(Version):
 		"""
 		Parse a version string and return a :class:`CalendarVersion` instance.
 
-		:param versionString: The version string to parse.
-		:returns:             An object representing a calendar version.
-		:raises TypeError:    If parameter ``other`` is not a string.
-		:raises ValueError:   If parameter ``other`` is None.
-		:raises ValueError:   If parameter ``other`` is empty.
-		"""
-		parts = Parts.Unknown
+		Allowed prefix characters:
 
+		* ``v|V`` - version, public version, public release
+		* ``i|I`` - internal version, internal release
+		* ``r|R`` - release, revision
+		* ``rev|REV`` - revision
+
+		:param versionString: The version string to parse.
+		:param validator:     Optional, a validation function.
+		:returns:             An object representing a calendar version.
+		:raises TypeError:    If parameter ``versionString`` is not a string.
+		:raises ValueError:   If parameter ``versionString`` is None.
+		:raises ValueError:   If parameter ``versionString`` is empty.
+		:raises ValueError:   If parameter ``versionString`` isn't a calendar version number.
+		"""
 		if versionString is None:
 			raise ValueError("Parameter 'versionString' is None.")
 		elif not isinstance(versionString, str):
 			ex = TypeError(f"Parameter 'versionString' is not of type 'str'.")
 			ex.add_note(f"Got type '{getFullyQualifiedName(versionString)}'.")
 			raise ex
-		elif versionString == "":
+		elif (versionString := versionString.strip()) == "":
 			raise ValueError("Parameter 'versionString' is empty.")
 
-		split = versionString.split(".")
-		length = len(split)
-		major = int(split[0])
-		minor = 0
-		parts |= Parts.Major
+		if (match := cls._PATTERN.match(versionString)) is None:
+			ex = ValueError(f"Syntax error in parameter 'versionString': '{versionString}'")
+			ex.add_note(f"A calendar version number is made of a major and an optional minor part, e.g. '2024.04'.")
+			ex.add_note(f"It may carry an alphabetic prefix, e.g. 'v2024.04'.")
+			raise ex
 
-		if length >= 2:
-			minor = int(split[1])
-			parts |= Parts.Minor
+		prefix = match["prefix"]
+		minor = match["minor"]
 
-		flags = Flags.Clean
+		version = cls(
+			int(match["major"]),
+			0 if minor is None else int(minor),
+			flags=Flags.Clean,
+			prefix=prefix if prefix != "" else None
+		)
 
-		version = cls(major, minor, flags=flags)
 		if validator is not None and not validator(version):
 			raise ValueError(f"Failed to validate version string '{versionString}'.")  # pragma: no cover
 
@@ -1663,19 +1681,20 @@ class CalendarVersion(Version):
 
 	def __repr__(self) -> str:
 		"""
-		Return a string representation of this version number without prefix ``v``.
-
-		:returns: Raw version number representation without a prefix.
-		"""
-		return f"{self._major}.{self._minor}"
-
-	def __str__(self) -> str:
-		"""
-		Return a string representation of this version number with prefix ``v``.
+		Return a string representation of this version number with all parts.
 
 		:returns: Version number representation including a prefix.
 		"""
-		result = f"{self._major}"
+		return f"{self._prefix if Parts.Prefix in self._parts else ''}{self._major}.{self._minor}"
+
+	def __str__(self) -> str:
+		"""
+		Return a string representation of this version number with only the present parts.
+
+		:returns: Version number representation including a prefix.
+		"""
+		result = self._prefix if Parts.Prefix in self._parts else ""
+		result += f"{self._major}"
 		result += f".{self._minor}" if Parts.Minor in self._parts else ""
 
 		return result

--- a/tests/unit/Configuration/JSON.py
+++ b/tests/unit/Configuration/JSON.py
@@ -32,6 +32,8 @@
 from pathlib  import Path
 from unittest import TestCase
 
+from pyTooling.Configuration      import InterpolationException, KeyNotFoundException, PathExpressionException
+from pyTooling.Configuration      import UnsupportedValueTypeException
 from pyTooling.Configuration.JSON import Configuration
 
 
@@ -107,3 +109,73 @@ class ReadingValues(TestCase):
 
 		self.assertEqual(r"C:\VendorA\ToolA\2020", config["Install"]["VendorA"]["ToolA"]["Defaults"]["InstallDir"])
 		self.assertEqual(r"C:\VendorA\ToolA\2020\bin", config["Install"]["VendorA"]["ToolA"]["Defaults"]["BinaryDir"])
+
+
+class Errors(TestCase):
+	_configFile = Path("tests/unit/Configuration/errors.json")
+
+	def test_UnknownKeyInDictionary(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(KeyNotFoundException) as context:
+			_ = config["dictionary"]["key_3"]
+
+		self.assertIn("Key 'key_3' not found in node 'dictionary'.", str(context.exception))
+		self.assertIn("Available keys: 'key_1', 'key_2'.", context.exception.__notes__)
+
+	def test_IndexOutOfRangeInSequence(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(KeyNotFoundException) as context:
+			_ = config["sequence"][2]
+
+		self.assertIn("Key '2' not found in node 'sequence'.", str(context.exception))
+		self.assertIn("Node 'sequence' is a sequence with indices 0..1.", context.exception.__notes__)
+
+	def test_UnknownKeyInEmptyDictionary(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(KeyNotFoundException) as context:
+			_ = config["emptyDictionary"]["key_1"]
+
+		self.assertIn("Node 'emptyDictionary' is an empty dictionary.", context.exception.__notes__)
+
+	def test_IndexInEmptySequence(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(KeyNotFoundException) as context:
+			_ = config["emptySequence"][0]
+
+		self.assertIn("Node 'emptySequence' is an empty sequence.", context.exception.__notes__)
+
+	def test_UnsupportedValueType(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(UnsupportedValueTypeException) as context:
+			_ = config["nullValue"]
+
+		self.assertIn("Unsupported type 'NoneType' for key 'nullValue'", str(context.exception))
+
+	def test_UnclosedVariableReference(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(InterpolationException) as context:
+			_ = config["unclosedVariable"]
+
+		self.assertIn("Unclosed variable reference in value '${unclosed'.", str(context.exception))
+
+	def test_DanglingDollarSign(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(InterpolationException) as context:
+			_ = config["danglingDollar"]
+
+		self.assertIn("Dangling '$' at the end of value 'prefix$'.", str(context.exception))
+
+	def test_PathExpressionResolvingToDictionary(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(PathExpressionException) as context:
+			_ = config["dictionaryReference"]
+
+		self.assertIn("resolves to a dictionary, not to a value", str(context.exception))

--- a/tests/unit/Configuration/YAML.py
+++ b/tests/unit/Configuration/YAML.py
@@ -32,6 +32,8 @@
 from pathlib  import Path
 from unittest import TestCase
 
+from pyTooling.Configuration      import InterpolationException, KeyNotFoundException, PathExpressionException
+from pyTooling.Configuration      import UnsupportedValueTypeException
 from pyTooling.Configuration.YAML import Configuration
 
 
@@ -107,3 +109,73 @@ class ReadingValues(TestCase):
 
 		self.assertEqual(r"C:\VendorA\ToolA\2020", config["Install"]["VendorA"]["ToolA"]["Defaults"]["InstallDir"])
 		self.assertEqual(r"C:\VendorA\ToolA\2020\bin", config["Install"]["VendorA"]["ToolA"]["Defaults"]["BinaryDir"])
+
+
+class Errors(TestCase):
+	_configFile = Path("tests/unit/Configuration/errors.yml")
+
+	def test_UnknownKeyInDictionary(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(KeyNotFoundException) as context:
+			_ = config["dictionary"]["key_3"]
+
+		self.assertIn("Key 'key_3' not found in node 'dictionary'.", str(context.exception))
+		self.assertIn("Available keys: 'key_1', 'key_2'.", context.exception.__notes__)
+
+	def test_IndexOutOfRangeInSequence(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(KeyNotFoundException) as context:
+			_ = config["sequence"][2]
+
+		self.assertIn("Key '2' not found in node 'sequence'.", str(context.exception))
+		self.assertIn("Node 'sequence' is a sequence with indices 0..1.", context.exception.__notes__)
+
+	def test_UnknownKeyInEmptyDictionary(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(KeyNotFoundException) as context:
+			_ = config["emptyDictionary"]["key_1"]
+
+		self.assertIn("Node 'emptyDictionary' is an empty dictionary.", context.exception.__notes__)
+
+	def test_IndexInEmptySequence(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(KeyNotFoundException) as context:
+			_ = config["emptySequence"][0]
+
+		self.assertIn("Node 'emptySequence' is an empty sequence.", context.exception.__notes__)
+
+	def test_UnsupportedValueType(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(UnsupportedValueTypeException) as context:
+			_ = config["nullValue"]
+
+		self.assertIn("Unsupported type 'NoneType' for key 'nullValue'", str(context.exception))
+
+	def test_UnclosedVariableReference(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(InterpolationException) as context:
+			_ = config["unclosedVariable"]
+
+		self.assertIn("Unclosed variable reference in value '${unclosed'.", str(context.exception))
+
+	def test_DanglingDollarSign(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(InterpolationException) as context:
+			_ = config["danglingDollar"]
+
+		self.assertIn("Dangling '$' at the end of value 'prefix$'.", str(context.exception))
+
+	def test_PathExpressionResolvingToDictionary(self) -> None:
+		config = Configuration(self._configFile)
+
+		with self.assertRaises(PathExpressionException) as context:
+			_ = config["dictionaryReference"]
+
+		self.assertIn("resolves to a dictionary, not to a value", str(context.exception))

--- a/tests/unit/Configuration/errors.json
+++ b/tests/unit/Configuration/errors.json
@@ -1,0 +1,16 @@
+{
+	"dictionary": {
+		"key_1": "value_1",
+		"key_2": "value_2"
+	},
+	"sequence": [
+		"item_0",
+		"item_1"
+	],
+	"emptyDictionary": {},
+	"emptySequence": [],
+	"nullValue": null,
+	"unclosedVariable": "${unclosed",
+	"danglingDollar": "prefix$",
+	"dictionaryReference": "${dictionary}"
+}

--- a/tests/unit/Configuration/errors.yml
+++ b/tests/unit/Configuration/errors.yml
@@ -1,0 +1,12 @@
+dictionary:
+  key_1: value_1
+  key_2: value_2
+sequence:
+  - item_0
+  - item_1
+emptyDictionary: {}
+emptySequence: []
+nullValue: null
+unclosedVariable: "${unclosed"
+danglingDollar: "prefix$"
+dictionaryReference: "${dictionary}"

--- a/tests/unit/Decorators/Decorators.py
+++ b/tests/unit/Decorators/Decorators.py
@@ -33,7 +33,7 @@ from unittest import TestCase
 
 from pytest   import mark
 
-from pyTooling.Decorators import export, InheritDocString, readonly
+from pyTooling.Decorators import export, InheritDocString, readonly, ReadOnlyProperty
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -125,10 +125,9 @@ class ReadOnly(TestCase):
 		with self.assertRaises(AttributeError):
 			del d.length
 
-	# FIXME: needs to be activated and tested
-	@mark.skip("EXPECTED ERROR IS NOT RAISED")
 	def test_Setter(self) -> None:
-		with self.assertRaises(AttributeError):
+		"""Attaching a setter to a read-only property is rejected while the class body is executed."""
+		with self.assertRaises(AttributeError) as context:
 			class Data:
 				_data: int
 
@@ -143,13 +142,11 @@ class ReadOnly(TestCase):
 				def length(self, value):
 					self._data = value
 
-			d = Data(6)
-			d.length = 16
+		self.assertIn("Property 'length' is read-only, so it can't have a setter.", str(context.exception))
 
-	# FIXME: needs to be activated and tested
-	@mark.skip("EXPECTED ERROR IS NOT RAISED")
 	def test_Deleter(self) -> None:
-		with self.assertRaises(AttributeError):
+		"""Attaching a deleter to a read-only property is rejected while the class body is executed."""
+		with self.assertRaises(AttributeError) as context:
 			class Data:
 				_data: int
 
@@ -161,11 +158,21 @@ class ReadOnly(TestCase):
 					return 2 ** self._data
 
 				@length.deleter
-				def length(self, value):
+				def length(self):
 					del self._data
 
-			d = Data(7)
-			del d.length
+		self.assertIn("Property 'length' is read-only, so it can't have a deleter.", str(context.exception))
+
+	def test_ReadOnlyPropertyType(self) -> None:
+		class Data:
+			_data: int
+
+			@readonly
+			def length(self) -> int:
+				return 2 ** self._data
+
+		self.assertIsInstance(Data.length, ReadOnlyProperty)
+		self.assertIsInstance(Data.length, property)
 
 
 class InheritDocStrings(TestCase):

--- a/tests/unit/Decorators/Decorators.py
+++ b/tests/unit/Decorators/Decorators.py
@@ -33,7 +33,7 @@ from unittest import TestCase
 
 from pytest   import mark
 
-from pyTooling.Decorators import export, InheritDocString, readonly, ReadOnlyProperty
+from pyTooling.Decorators import export, InheritDocString, readonly
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -169,10 +169,12 @@ class ReadOnly(TestCase):
 
 			@readonly
 			def length(self) -> int:
+				"""Doc-string of the getter."""
 				return 2 ** self._data
 
-		self.assertIsInstance(Data.length, ReadOnlyProperty)
+		self.assertIsInstance(Data.length, readonly)
 		self.assertIsInstance(Data.length, property)
+		self.assertEqual("Doc-string of the getter.", Data.length.__doc__)
 
 
 class InheritDocStrings(TestCase):

--- a/tests/unit/Graph/__init__.py
+++ b/tests/unit/Graph/__init__.py
@@ -35,6 +35,7 @@ from unittest import TestCase
 from pyTooling.Decorators import readonly
 from pyTooling.Graph      import Graph, Vertex, Edge, Link, Subgraph, View, DuplicateVertexError, CycleError
 from pyTooling.Graph      import GraphException, DuplicateEdgeError, NotInSameGraph, DestinationNotReachable
+from pyTooling.Graph      import NotInDifferentSubgraphs
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -1039,6 +1040,34 @@ class EdgesAndLinks(TestCase):
 		self.assertEqual(vertex3, edge34.Source)
 		self.assertEqual(vertex4, edge34.Destination)
 		self.assertEqual(2, edge34.Weight)
+
+	def test_EdgeAcrossSubgraphBoundary(self) -> None:
+		"""An edge can only connect vertices within the same graph or subgraph."""
+		graph = Graph()
+		subgraph = Subgraph(graph=graph)
+		vertex1 = Vertex(vertexID=1, graph=graph)
+		vertex2 = Vertex(vertexID=2, subgraph=subgraph)
+
+		for methodName in ("EdgeToVertex", "EdgeFromVertex"):
+			with self.subTest(method=methodName):
+				with self.assertRaises(NotInSameGraph) as context:
+					_ = getattr(vertex1, methodName)(vertex2)
+
+				self.assertIn("are not in the same graph or subgraph", str(context.exception))
+
+	def test_LinkWithinSameSubgraph(self) -> None:
+		"""A link can only connect vertices across subgraph boundaries."""
+		graph = Graph()
+		subgraph = Subgraph(graph=graph)
+		vertex1 = Vertex(vertexID=1, subgraph=subgraph)
+		vertex2 = Vertex(vertexID=2, subgraph=subgraph)
+
+		for methodName in ("LinkToVertex", "LinkFromVertex"):
+			with self.subTest(method=methodName):
+				with self.assertRaises(NotInDifferentSubgraphs) as context:
+					_ = getattr(vertex1, methodName)(vertex2)
+
+				self.assertIn("are in the same subgraph", str(context.exception))
 
 
 class Iterate(TestCase):

--- a/tests/unit/MetaClasses/Abstract.py
+++ b/tests/unit/MetaClasses/Abstract.py
@@ -33,8 +33,8 @@ Unit tests for class :class:`pyTooling.MetaClasses.ExtendedType`.
 
 This test suite tests decorators:
 
-* :func:`@abstractmethod <pyTooling.MetaClasses.abstractmethod>`
-* :func:`@mustoverride <pyTooling.MetaClasses.mustoverride>`
+* :deco:`~pyTooling.MetaClasses.abstractmethod`
+* :deco:`~pyTooling.MetaClasses.mustoverride`
 """
 from unittest              import TestCase
 

--- a/tests/unit/MetaClasses/ClassDecorators.py
+++ b/tests/unit/MetaClasses/ClassDecorators.py
@@ -1,0 +1,142 @@
+# ==================================================================================================================== #
+#             _____           _ _               __  __      _         ____ _                                           #
+#  _ __  _   |_   _|__   ___ | (_)_ __   __ _  |  \/  | ___| |_ __ _ / ___| | __ _ ___ ___  ___  ___                   #
+# | '_ \| | | || |/ _ \ / _ \| | | '_ \ / _` | | |\/| |/ _ \ __/ _` | |   | |/ _` / __/ __|/ _ \/ __|                  #
+# | |_) | |_| || | (_) | (_) | | | | | | (_| |_| |  | |  __/ || (_| | |___| | (_| \__ \__ \  __/\__ \                  #
+# | .__/ \__, ||_|\___/ \___/|_|_|_| |_|\__, (_)_|  |_|\___|\__\__,_|\____|_|\__,_|___/___/\___||___/                  #
+# |_|    |___/                          |___/                                                                          #
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# License:                                                                                                             #
+# ==================================================================================================================== #
+# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
+#
+"""
+Unit tests for the class decorators :func:`~pyTooling.MetaClasses.slotted`,
+:func:`~pyTooling.MetaClasses.mixin` and :func:`~pyTooling.MetaClasses.singleton`.
+"""
+from unittest              import TestCase
+
+from pyTooling.MetaClasses import ExtendedType, IncompatibleMetaClassError, mixin, singleton, slotted
+
+
+if __name__ == "__main__":  # pragma: no cover
+	print("ERROR: you called a testcase declaration file as an executable module.")
+	print("Use: 'python -m unittest <testcase module>'")
+	exit(1)
+
+
+class Slotted(TestCase):
+	def test_PlainClass(self) -> None:
+		@slotted
+		class Data:
+			_data_0: int
+
+			def __init__(self, data: int) -> None:
+				self._data_0 = data
+
+		self.assertTrue(Data.__slotted__)
+		self.assertIn("_data_0", Data.__slots__)
+
+		inst = Data(5)
+
+		self.assertEqual(5, inst._data_0)
+
+		with self.assertRaises(AttributeError):
+			inst._data_1 = 6
+
+
+class Mixin(TestCase):
+	def test_PlainClass(self) -> None:
+		@mixin
+		class Mixed:
+			_data_M1: int
+
+		self.assertTrue(Mixed.__isMixin__)
+		self.assertEqual(tuple(), Mixed.__slots__)
+		self.assertIn("_data_M1", Mixed.__mixinSlots__)
+
+	def test_MergedIntoPrimaryInheritanceLine(self) -> None:
+		@mixin
+		class Mixed:
+			_data_M1: int
+
+		class Primary(metaclass=ExtendedType, slots=True):
+			_data_L1: int
+
+		class Final(Primary, Mixed, metaclass=ExtendedType, slots=True):
+			def __init__(self) -> None:
+				self._data_L1 = 1
+				self._data_M1 = 2
+
+		inst = Final()
+
+		self.assertEqual(1, inst._data_L1)
+		self.assertEqual(2, inst._data_M1)
+
+
+class Singleton(TestCase):
+	def test_PlainClass(self) -> None:
+		@singleton
+		class App:
+			_data_0: int
+
+			def __init__(self) -> None:
+				self._data_0 = 5
+
+		self.assertIs(App(), App())
+
+
+class IncompatibleMetaClass(TestCase):
+	"""
+	A decorated class must use :class:`type` or a meta-class derived from
+	:class:`~pyTooling.MetaClasses.ExtendedType`.
+	"""
+
+	class OtherMeta(type):
+		pass
+
+	def test_Slotted(self) -> None:
+		class Data(metaclass=self.OtherMeta):
+			pass
+
+		with self.assertRaises(IncompatibleMetaClassError) as context:
+			_ = slotted(Data)
+
+		self.assertIn("'@slotted'", str(context.exception))
+		self.assertIn("OtherMeta", context.exception.__notes__[0])
+
+	def test_Mixin(self) -> None:
+		class Data(metaclass=self.OtherMeta):
+			pass
+
+		with self.assertRaises(IncompatibleMetaClassError) as context:
+			_ = mixin(Data)
+
+		self.assertIn("'@mixin'", str(context.exception))
+
+	def test_Singleton(self) -> None:
+		class Data(metaclass=self.OtherMeta):
+			pass
+
+		with self.assertRaises(IncompatibleMetaClassError) as context:
+			_ = singleton(Data)
+
+		self.assertIn("'@singleton'", str(context.exception))

--- a/tests/unit/MetaClasses/ClassDecorators.py
+++ b/tests/unit/MetaClasses/ClassDecorators.py
@@ -29,8 +29,8 @@
 # ==================================================================================================================== #
 #
 """
-Unit tests for the class decorators :func:`~pyTooling.MetaClasses.slotted`,
-:func:`~pyTooling.MetaClasses.mixin` and :func:`~pyTooling.MetaClasses.singleton`.
+Unit tests for the class decorators :deco:`~pyTooling.MetaClasses.slotted`,
+:deco:`~pyTooling.MetaClasses.mixin` and :deco:`~pyTooling.MetaClasses.singleton`.
 """
 from unittest              import TestCase
 

--- a/tests/unit/MetaClasses/Serialization.py
+++ b/tests/unit/MetaClasses/Serialization.py
@@ -33,8 +33,8 @@ Unit tests for class :class:`pyTooling.MetaClasses.ExtendedType`.
 
 This test suite tests decorators:
 
-* :func:`@abstractmethod <pyTooling.MetaClasses.abstractmethod>`
-* :func:`@mustoverride <pyTooling.MetaClasses.mustoverride>`
+* :deco:`~pyTooling.MetaClasses.abstractmethod`
+* :deco:`~pyTooling.MetaClasses.mustoverride`
 """
 from pickle                import loads, dumps
 from typing                import Dict, Any

--- a/tests/unit/MetaClasses/SlottedType.py
+++ b/tests/unit/MetaClasses/SlottedType.py
@@ -31,12 +31,13 @@
 """
 Unit tests for class :class:`pyTooling.MetaClasses.ExtendedType`.
 """
-from typing                import Optional as Nullable
+from typing                import ClassVar, Optional as Nullable
 from unittest              import TestCase
 
 from pytest                import mark
 
 from pyTooling.MetaClasses import ExtendedType, BaseClassIsNotAMixinError, BaseClassWithNonEmptySlotsError, BaseClassWithoutSlotsError
+from pyTooling.MetaClasses import DuplicateFieldInSlotsError
 from pyTooling.Common      import getsizeof
 from pyTooling.Platform    import CurrentPlatform
 
@@ -1061,6 +1062,125 @@ class Inheritance(TestCase):
 			# self.assertEqual(16, inst._data_R1)
 			# self.assertEqual(17, inst._data_2)
 			# self.assertEqual(18, inst._data_3)
+
+
+class NonEmptySlotsOnSecondaryBaseClass(TestCase):
+	"""
+	Only the primary inheritance line may use non-empty ``__slots__``. Secondary base-classes must be mixin-classes,
+	otherwise Python reports an instance lay-out conflict.
+	"""
+
+	def test_PlainClassWithNonEmptySlots(self) -> None:
+		"""A secondary base-class not built by ExtendedType is checked as well."""
+		class Plain:
+			__slots__ = ("_data_R1", )
+
+		class Primary(metaclass=ExtendedType, slots=True):
+			_data_L1: int
+
+		with self.assertRaises(BaseClassWithNonEmptySlotsError) as context:
+			class Final(Primary, Plain, metaclass=ExtendedType, slots=True):
+				_data_2: int
+
+		self.assertIn("Plain", str(context.exception))
+
+	def test_IndirectlyInheritedNonEmptySlots(self) -> None:
+		"""A mixin-class may not drag in a non-mixin base-class using non-empty slots."""
+		class Plain:
+			__slots__ = ("_data_R1", )
+
+		class Mixin(Plain, metaclass=ExtendedType, mixin=True):
+			_data_M1: int
+
+		class Primary(metaclass=ExtendedType, slots=True):
+			_data_L1: int
+
+		with self.assertRaises(BaseClassWithNonEmptySlotsError) as context:
+			class Final(Primary, Mixin, metaclass=ExtendedType, slots=True):
+				_data_2: int
+
+		self.assertIn("Plain", str(context.exception))
+
+	def test_ProperMixinIsAccepted(self) -> None:
+		class Mixin(metaclass=ExtendedType, mixin=True):
+			_data_M1: int
+
+		class Primary(metaclass=ExtendedType, slots=True):
+			_data_L1: int
+
+		class Final(Primary, Mixin, metaclass=ExtendedType, slots=True):
+			_data_2: int
+
+			def __init__(self) -> None:
+				self._data_L1 = 1
+				self._data_M1 = 2
+				self._data_2 = 3
+
+		inst = Final()
+
+		self.assertEqual(1, inst._data_L1)
+		self.assertEqual(2, inst._data_M1)
+		self.assertEqual(3, inst._data_2)
+
+
+class SlotShadowedByClassMember(TestCase):
+	"""
+	A class member assigned without a type annotation stays a class attribute. If it carries the name of a slot, it
+	shadows the slot's descriptor and the field becomes read-only on instances - which used to surface much later as a
+	bare ``AttributeError: ... is read-only`` on the first assignment.
+	"""
+
+	def test_ShadowedInheritedSlot(self) -> None:
+		class Base(metaclass=ExtendedType, slots=True):
+			_data_0: int
+
+			def __init__(self) -> None:
+				self._data_0 = 1
+
+		with self.assertRaises(DuplicateFieldInSlotsError) as context:
+			class Derived(Base):
+				_data_0 = 5
+
+		self.assertIn("_data_0", str(context.exception))
+		self.assertIn("Slot '_data_0' is declared in base-class", context.exception.__notes__[0])
+
+	def test_ShadowedMixinSlot(self) -> None:
+		class Mixin(metaclass=ExtendedType, mixin=True):
+			_data_M1: int
+
+		class Primary(metaclass=ExtendedType, slots=True):
+			_data_L1: int
+
+		with self.assertRaises(DuplicateFieldInSlotsError) as context:
+			class Final(Primary, Mixin, metaclass=ExtendedType, slots=True):
+				_data_M1 = 5
+
+		self.assertIn("Slot '_data_M1' is contributed by a mixin-class.", context.exception.__notes__[0])
+
+	def test_ClassVariableIsNotShadowing(self) -> None:
+		"""Annotating the assignment as a ClassVar is the documented way out."""
+		class Base(metaclass=ExtendedType, slots=True):
+			_data_0: ClassVar[int]
+
+		class Derived(Base):
+			_data_0: ClassVar[int] = 5
+
+		self.assertEqual(5, Derived._data_0)
+		self.assertEqual(5, Derived()._data_0)
+
+	def test_UnrelatedClassConstantIsAccepted(self) -> None:
+		"""An un-annotated assignment that doesn't collide with a slot stays a plain class attribute."""
+		class Base(metaclass=ExtendedType, slots=True):
+			LIMIT = 100
+			_data_0: int
+
+			def __init__(self) -> None:
+				self._data_0 = self.LIMIT
+
+		inst = Base()
+
+		self.assertEqual(100, Base.LIMIT)
+		self.assertEqual(100, inst._data_0)
 
 
 class Hierarchy(TestCase):

--- a/tests/unit/MetaClasses/SlottedType.py
+++ b/tests/unit/MetaClasses/SlottedType.py
@@ -37,7 +37,9 @@ from unittest              import TestCase
 from pytest                import mark
 
 from pyTooling.MetaClasses import ExtendedType, BaseClassIsNotAMixinError, BaseClassWithNonEmptySlotsError, BaseClassWithoutSlotsError
-from pyTooling.MetaClasses import DuplicateFieldInSlotsError
+from pyTooling.MetaClasses import DuplicateFieldInSlotsError, UnannotatedFieldWarning
+from pyTooling.Decorators  import readonly
+from pyTooling.Warning     import WarningCollector
 from pyTooling.Common      import getsizeof
 from pyTooling.Platform    import CurrentPlatform
 
@@ -1181,6 +1183,90 @@ class SlotShadowedByClassMember(TestCase):
 
 		self.assertEqual(100, Base.LIMIT)
 		self.assertEqual(100, inst._data_0)
+
+
+class UnannotatedFields(TestCase):
+	"""
+	Every field should carry type information. A field assigned in the class body without a type annotation is reported
+	as a warning - it needs a :class:`WarningCollector` to be observed, so importing such a module doesn't fail.
+	"""
+
+	def _collect(self, construct) -> list:
+		warnings = []
+		with WarningCollector(handler=lambda warning: warnings.append(warning) or False):
+			construct()
+
+		return [warning for warning in warnings if isinstance(warning, UnannotatedFieldWarning)]
+
+	def test_UnannotatedClassConstant(self) -> None:
+		def construct() -> None:
+			class Base(metaclass=ExtendedType, slots=True):
+				LIMIT = 100
+				_data_0: int
+
+		warnings = self._collect(construct)
+
+		self.assertEqual(1, len(warnings))
+		self.assertIn("Class 'Base' declares 1 field(s) without a type annotation.", str(warnings[0]))
+		self.assertIn("'LIMIT'", warnings[0].__notes__[0])
+
+	def test_UnannotatedFieldWithoutSlots(self) -> None:
+		"""The check doesn't depend on slots - it's about type information, not about the slot machinery."""
+		def construct() -> None:
+			class Base(metaclass=ExtendedType):
+				LIMIT = 100
+
+		self.assertEqual(1, len(self._collect(construct)))
+
+	def test_ClassVarIsAnnotated(self) -> None:
+		def construct() -> None:
+			class Base(metaclass=ExtendedType, slots=True):
+				LIMIT: ClassVar[int] = 100
+				_data_0: int
+
+		self.assertEqual(0, len(self._collect(construct)))
+
+	def test_MethodsAndNestedClassesAreNoFields(self) -> None:
+		def construct() -> None:
+			class Base(metaclass=ExtendedType, slots=True):
+				_data_0: int
+
+				class Nested:
+					pass
+
+				def Method(self) -> None:
+					pass
+
+				@classmethod
+				def ClassMethod(cls) -> None:
+					pass
+
+				@staticmethod
+				def StaticMethod() -> None:
+					pass
+
+				@property
+				def Property(self) -> int:
+					return self._data_0
+
+				@readonly
+				def ReadOnly(self) -> int:
+					return self._data_0
+
+		self.assertEqual(0, len(self._collect(construct)))
+
+	def test_MultipleUnannotatedFields(self) -> None:
+		def construct() -> None:
+			class Base(metaclass=ExtendedType, slots=True):
+				LIMIT = 100
+				NAME = "base"
+				_data_0: int
+
+		warnings = self._collect(construct)
+
+		self.assertEqual(1, len(warnings))
+		self.assertIn("declares 2 field(s)", str(warnings[0]))
+		self.assertIn("'LIMIT', 'NAME'", warnings[0].__notes__[0])
 
 
 class Hierarchy(TestCase):

--- a/tests/unit/Versioning/CalVersion.py
+++ b/tests/unit/Versioning/CalVersion.py
@@ -138,11 +138,42 @@ class Parsing(TestCase):
 		self.assertEqual(2024, version.Major)
 		self.assertEqual(4, version.Minor)
 
+	def test_String_MajorMinorMicro(self) -> None:
+		version = CalendarVersion.Parse("2024.10.15")
+
+		self.assertEqual(2024, version.Major)
+		self.assertEqual(10, version.Minor)
+		self.assertEqual(15, version.Micro)
+		self.assertEqual("2024.10.15", str(version))
+
+	def test_MicroWithPrefix(self) -> None:
+		version = CalendarVersion.Parse("v2024.10.15")
+
+		self.assertEqual("v", version.Prefix)
+		self.assertEqual("v2024.10.15", str(version))
+		self.assertEqual("v2024.10.15", repr(version))
+
 	def test_TooManyParts(self) -> None:
 		with self.assertRaises(ValueError) as context:
-			CalendarVersion.Parse("2024.04.1")
+			CalendarVersion.Parse("2024.04.1.7")
 
 		self.assertIn("Syntax error", str(context.exception))
+
+	def test_ThirdPartOnTwoPartClass(self) -> None:
+		for cls in (YearMonthVersion, YearWeekVersion, YearReleaseVersion):
+			with self.subTest(versionClass=cls.__name__):
+				with self.assertRaises(ValueError) as context:
+					cls.Parse("2024.10.15")
+
+				self.assertIn(f"'{cls.__name__}' describes 2", str(context.exception))
+
+	def test_ThirdPartOnYearMonthDay(self) -> None:
+		version = YearMonthDayVersion.Parse("2024.10.15")
+
+		self.assertEqual(2024, version.Year)
+		self.assertEqual(10, version.Month)
+		self.assertEqual(15, version.Day)
+		self.assertEqual("2024.10.15", str(version))
 
 
 # class CompareVersions(TestCase):

--- a/tests/unit/Versioning/CalVersion.py
+++ b/tests/unit/Versioning/CalVersion.py
@@ -151,7 +151,7 @@ class Parsing(TestCase):
 
 		self.assertEqual("v", version.Prefix)
 		self.assertEqual("v2024.10.15", str(version))
-		self.assertEqual("v2024.10.15", repr(version))
+		self.assertEqual("2024.10.15", repr(version))
 
 	def test_TooManyParts(self) -> None:
 		with self.assertRaises(ValueError) as context:
@@ -507,9 +507,10 @@ class FormattingUsingRepr(TestCase):
 		self.assertEqual("1.0", repr(version))
 
 	def test_MajorPrefix(self) -> None:
+		"""A prefix doesn't contribute to the version's value, so repr - the normalized form - omits it."""
 		version = CalendarVersion(1, prefix="v")
 
-		self.assertEqual("v1.0", repr(version))
+		self.assertEqual("1.0", repr(version))
 
 	def test_MajorMinor(self) -> None:
 		version = CalendarVersion(1, 2)

--- a/tests/unit/Versioning/CalVersion.py
+++ b/tests/unit/Versioning/CalVersion.py
@@ -30,9 +30,7 @@
 #
 """Unit tests for package :mod:`pyTooling.Versioning`."""
 from unittest             import TestCase
-from pytest               import mark
-
-from pyTooling.Versioning import Flags, CalendarVersion, WordSizeValidator, MaxValueValidator
+from pyTooling.Versioning import Flags, Parts, CalendarVersion, WordSizeValidator, MaxValueValidator
 from pyTooling.Versioning import YearMonthVersion, YearWeekVersion, YearReleaseVersion, YearMonthDayVersion
 
 
@@ -102,26 +100,49 @@ class Parsing(TestCase):
 		self.assertEqual(1, version.Major)
 		self.assertEqual(2, version.Minor)
 
-	@mark.xfail(reason="v2024.04 not yet support")
 	def test_vString(self) -> None:
 		version = CalendarVersion.Parse("v1.2")
 
 		self.assertEqual(1, version.Major)
 		self.assertEqual(2, version.Minor)
 
-	@mark.xfail(reason="i2024.04 not yet support")
 	def test_iString(self) -> None:
 		version = CalendarVersion.Parse("i1.2")
 
 		self.assertEqual(1, version.Major)
 		self.assertEqual(2, version.Minor)
 
-	@mark.xfail(reason="r2024.04 not yet support")
 	def test_rString(self) -> None:
 		version = CalendarVersion.Parse("r1.2")
 
 		self.assertEqual(1, version.Major)
 		self.assertEqual(2, version.Minor)
+
+	def test_PrefixIsPreserved(self) -> None:
+		version = CalendarVersion.Parse("v2024.04")
+
+		self.assertEqual("v", version.Prefix)
+		self.assertIn(Parts.Prefix, version.Parts)
+		self.assertEqual("v2024.4", str(version))
+
+	def test_NoPrefix(self) -> None:
+		version = CalendarVersion.Parse("2024.04")
+
+		self.assertEqual("", version.Prefix)
+		self.assertNotIn(Parts.Prefix, version.Parts)
+
+	def test_MultiCharacterPrefix(self) -> None:
+		version = CalendarVersion.Parse("rev2024.04")
+
+		self.assertEqual("rev", version.Prefix)
+		self.assertEqual(2024, version.Major)
+		self.assertEqual(4, version.Minor)
+
+	def test_TooManyParts(self) -> None:
+		with self.assertRaises(ValueError) as context:
+			CalendarVersion.Parse("2024.04.1")
+
+		self.assertIn("Syntax error", str(context.exception))
 
 
 # class CompareVersions(TestCase):
@@ -454,7 +475,6 @@ class FormattingUsingRepr(TestCase):
 
 		self.assertEqual("1.0", repr(version))
 
-	@mark.xfail(reason="v2024.04 not yet support")
 	def test_MajorPrefix(self) -> None:
 		version = CalendarVersion(1, prefix="v")
 
@@ -472,7 +492,6 @@ class FormattingUsingStr(TestCase):
 
 		self.assertEqual("1", str(version))
 
-	@mark.xfail(reason="v2024.04 not yet support")
 	def test_MajorPrefix(self) -> None:
 		version = CalendarVersion(1, prefix="v")
 

--- a/tests/unit/Versioning/SemVersion.py
+++ b/tests/unit/Versioning/SemVersion.py
@@ -31,7 +31,7 @@
 """Unit tests for package :mod:`pyTooling.Versioning`."""
 from unittest             import TestCase
 
-from pyTooling.Versioning import Flags, ReleaseLevel, SemanticVersion, WordSizeValidator, MaxValueValidator
+from pyTooling.Versioning import Flags, Parts, ReleaseLevel, SemanticVersion, WordSizeValidator, MaxValueValidator
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -379,6 +379,28 @@ class Parsing(TestCase):
 		self.assertEqual(2, version.Minor)
 		self.assertEqual(3, version.Micro)
 		self.assertEqual(ReleaseLevel.Final, version.ReleaseLevel)
+
+	def test_revString(self) -> None:
+		version = SemanticVersion.Parse("rev1.2.3")
+
+		self.assertEqual("rev", version.Prefix)
+		self.assertEqual(1, version.Major)
+
+	def test_UndocumentedPrefix(self) -> None:
+		"""Only the documented prefixes are accepted - 'deb1.2.3' used to parse with prefix 'deb'."""
+		for versionString in ("abc1.2.3", "deb1.2.3", "x1.2.3"):
+			with self.subTest(versionString=versionString):
+				with self.assertRaises(ValueError) as context:
+					SemanticVersion.Parse(versionString)
+
+				self.assertIn("Syntax error", str(context.exception))
+
+	def test_NoPrefix(self) -> None:
+		"""Without a prefix, Parts.Prefix must not be set - it used to be set with an empty string."""
+		version = SemanticVersion.Parse("1.2.3")
+
+		self.assertEqual("", version.Prefix)
+		self.assertNotIn(Parts.Prefix, version.Parts)
 
 	def test_MajorMinorDev(self) -> None:
 		version = SemanticVersion.Parse("0.6-dev")

--- a/tests/unit/Versioning/SemVersion.py
+++ b/tests/unit/Versioning/SemVersion.py
@@ -809,7 +809,8 @@ class FormattingUsingRepr(TestCase):
 		self.assertEqual("1.0.0", repr(version))
 
 	def test_MajorPrefix(self) -> None:
-		version = SemanticVersion(1)
+		"""A prefix doesn't contribute to the version's value, so repr - the normalized form - omits it."""
+		version = SemanticVersion(1, prefix="v")
 
 		self.assertEqual("1.0.0", repr(version))
 


### PR DESCRIPTION
# New Features

* `pyTooling.Configuration`:
  * Added `KeyNotFoundException`, raised when a key or index doesn't exist. Its note lists the node's actual keys or its valid index range.
  * Added `UnsupportedValueTypeException`, raised when the parser returns a value type the package doesn't support.
  * Added `InterpolationException`, raised for a malformed `${...}` reference.
  * Added `PathExpressionException`, raised when a path expression doesn't address a value.
* `pyTooling.Dependency`:
  * Added `DependencyException` as base-exception of the module.
  * Added `NoSessionAvailableException`, `ProjectNotFoundException` and `ReleaseNotFoundException`.
  * Added `BrokenRequirementWarning` and `ReleaseDetailsWarning`.
* `pyTooling.Graph`:
  * Added `NotInDifferentSubgraphs`, raised when a link connects two vertices within the same subgraph. It's the counterpart to `NotInSameGraph`.
* `pyTooling.MetaClasses`:
  * Added `IncompatibleMetaClassError`, raised by `@slotted`, `@mixin` and `@singleton`.
  * Added `UnannotatedFieldWarning`.
  * `ExtendedType` reports every field assigned in a class body without a type annotation. Methods, nested classes, properties, descriptors, builtins and dunder members aren't fields and are skipped. It's a warning, so it needs a `WarningCollector` up the call-hierarchy to be observed and importing a module doesn't fail.
  * `ExtendedType` rejects a slot shadowed by a class member with a `DuplicateFieldInSlotsError`, naming the base-class or mixin-class the slot came from.
* `pyTooling.Versioning`:
  * `CalendarVersion` accepts the `v`, `i`, `r` and `rev` prefixes, like `SemanticVersion` always has.
  * `CalendarVersion` carries a third numeric part, e.g. `2024.10.15`. How many parts a class describes is declared as `_PARTCOUNT`.
  * `CalendarVersion.__format__` gained the `%u` specifier for the micro part, matching `SemanticVersion`.

# Changes

* `pyTooling.Decorators`:
  * `readonly` is now a class deriving from `property`, replacing the function that returned one. `property` is itself a class used as a decorator, so the wrapper bought nothing.
  * A read-only property rejects `<property>.setter` and `<property>.deleter` with an `AttributeError`. The doc-string always claimed both were removed, but a plain `property` hands them out, so a property declared read-only could be made writable further down the class body.
* `pyTooling.MetaClasses`:
  * A `ClassVar` without an initial value no longer becomes a slot. It's a forward declaration for derived classes to assign.
  * `@slotted`, `@mixin` and `@singleton` share `_recreateClass`. They were byte-identical apart from their final keyword argument.
  * The three decorators raise `IncompatibleMetaClassError` naming the class and its meta-class, replacing `ExtendedTypeError("Class uses an incompatible meta-class.")`.
  * Both branches of `_computeSlots` share `_getAnnotations` and `_isClassVariable`.
* `pyTooling.Configuration`:
  * `_LookupKey` replaces the nested `try`/`except` chain and tries the key as string, integer and float.
  * The `Sequence` iterator bound-checks against `len()` instead of relying on an `IndexError` travelling up from the lookup.
* `pyTooling.Graph`:
  * Six `GraphException()` raised without any message now raise `NotInSameGraph` or `NotInDifferentSubgraphs`, naming both vertices and pointing at the other method (edge vs. link) that fits.
* `pyTooling.Dependency`:
  * Four generic `ToolingException` raises replaced with specific types, chaining from the `HTTPError` that caused them.
  * Broken requirements and dropped releases raise a warning. One of them printed to stdout from library code.
* `pyTooling.Versioning`:
  * `SemanticVersion` accepts only the documented prefixes. `[a-zA-Z]*` accepted any alphabetic prefix, so `abc1.2.3` parsed with prefix `abc`. Both version classes now use the same pattern.
  * `__repr__` returns the normalized form on both version classes, so a prefix isn't part of it.
  * `CalendarVersion.Parse` rejects more than three numeric parts. The old `versionString.split(".")` read the first two elements and discarded the rest, so `2024.04.1` silently parsed as `2024.04`.
* `pyTooling.Cartesian2D` and `pyTooling.Cartesian3D`:
  * `Copy`, `__iadd__` and `__isub__` return `Self` instead of a forward-referenced class name. `Self` is also more precise: every `Copy` builds its result with `self.__class__(...)`, so a subclass gets its own type back.
* Class variables in `Versioning`, `GenericPath`, `Graph.GraphML` and `TerminalUI` are annotated with `ClassVar[...]`. A fresh import of every module raises no `UnannotatedFieldWarning`.

# Bug Fixes

* `pyTooling.Configuration`:
  * A missing string key raised `ValueError: invalid literal for int() with base 10: '...'`, because the `int(key)` conversion was never guarded.
  * A missing numeric key raised `Exception("")` — an exception with an empty message.
  * A `null` value raised the same empty exception. This is reachable from any valid JSON or YAML file.
* `pyTooling.MetaClasses`:
  * A `ClassVar` without an initial value became a slot, so the field was read-only on instances of every derived class, and such objects were unpicklable — `pickle`'s default `__setstate__` writes every slot back and hit the same `AttributeError`.
  * The non-slots branch of `_computeSlots` had no [PEP 649](https://peps.python.org/pep-0649/) fallback and read only `members["__annotations__"]`. Since Python 3.14 installs `__annotate_func__` instead, that branch saw no annotations at all and never collected class fields.
* `pyTooling.Versioning`:
  * `VersionRange.UpperBound` and `VersionRange.BoundHandling` were declared `@readonly` and then given a setter, unlike their sibling `LowerBound`. The read-only marker was silently a lie on both.
  * `SemanticVersion.__repr__` emitted the prefix while its doc-string said it doesn't.
  * `SemanticVersion.Parse` set `Parts.Prefix` for a version string without a prefix, because `[a-zA-Z]*` matched the empty string and `Version.__init__` only tests `prefix is not None`.
  * `YearMonthDayVersion` dropped the day from `__str__` and `__repr__`. `YearMonthDayVersion(2024, 10, 15)` formatted as `2024.10`, in the one class that exists to carry three parts.

# Documentation

* Decorators are cross-referenced with `:deco:`, which renders `@name` instead of `name()`. 28 references converted.
  * Six references pointed at `pyTooling.Metaclasses` (lowercase `c`) and never resolved. Two of those also named the wrong module — `notimplemented` lives in `pyTooling.Decorators`.
  * `:deco:` resolves only against objects documented in this project. Intersphinx looks up `objtypes_for_role("deco")`, no object type declares that role, and the lookup returns nothing — so `:deco:` must not be used for `property` or anything else from the CPython docs, or the link silently disappears. This is an unreported Sphinx bug.
* Added an `.. important::` admonition explaining the [PEP 649](https://peps.python.org/pep-0649/) annotation handling.
* Added a `.. note::` to both `__repr__` doc-strings explaining the normalized form.
* Added doc-strings for all new exceptions and warnings.

# Unit Tests

* 1154 → 1212 passing, 8 → 3 xfailed, 33 → 31 skipped.
* Added `tests/unit/MetaClasses/ClassDecorators.py`. `@slotted`, `@mixin` and `@singleton` had no test coverage at all.
* Added `Errors` test classes to the JSON and YAML configuration tests, with `errors.json` and `errors.yml` fixtures.
* Added `NonEmptySlotsOnSecondaryBaseClass`, `SlotShadowedByClassMember` and `UnannotatedFields` to the slotted-type tests.
* Un-skipped `ReadOnly.test_Setter` and `ReadOnly.test_Deleter`, which were marked `EXPECTED ERROR IS NOT RAISED`.
* Un-xfailed the five `CalendarVersion` prefix tests.
* Added subgraph boundary tests for edges and links.
* Added prefix and micro tests for both version classes, including `Parts.Prefix` on a prefix-less parse.

----------
# Related Issues and Pull-Requests

* #261
* #263
