### PR TITLE
Document all properties and correct their decoration

### DIFF
--- a/pyTooling/Attributes/ArgParse/__init__.py
+++ b/pyTooling/Attributes/ArgParse/__init__.py
@@ -64,7 +64,11 @@ class _HandlerMixin(metaclass=ExtendedType, mixin=True):
 
 	@readonly
 	def Handler(self) -> Callable:
-		"""Returns the handler method."""
+		"""
+		Read-only property to access the handler method (:attr:`_handler`).
+
+		:returns: The method called to handle the command.
+		"""
 		return self._handler
 
 
@@ -117,6 +121,8 @@ class CommandLineArgument(ArgParseAttribute, _HandlerMixin):
 		"""
 		A tuple of additional positional parameters (``*args``) passed to the attribute. These additional parameters are
 		passed without modification to :class:`~ArgumentParser`.
+
+		:returns: Tuple of positional parameters.
 		"""
 		return self._args
 
@@ -125,6 +131,8 @@ class CommandLineArgument(ArgParseAttribute, _HandlerMixin):
 		"""
 		A dictionary of additional named parameters (``**kwargs``) passed to the attribute. These additional parameters are
 		passed without modification to :class:`~ArgumentParser`.
+
+		:returns: Dictionary of named parameters.
 		"""
 		return self._kwargs
 
@@ -145,7 +153,11 @@ class CommandGroupAttribute(ArgParseAttribute):
 
 	@readonly
 	def GroupName(self) -> str:
-		"""Returns the name of the command group."""
+		"""
+		Read-only property to access the name of the command group (:attr:`_groupName`).
+
+		:returns: Name of the command group.
+		"""
 		return self.__groupName
 
 
@@ -225,7 +237,11 @@ class CommandHandler(ArgParseAttribute, _HandlerMixin):  #, _KwArgsMixin):
 
 	@readonly
 	def Command(self) -> str:
-		"""Returns the 'command' a sub-command parser adheres to."""
+		"""
+		Read-only property to access the command a sub-command parser adheres to (:attr:`_command`).
+
+		:returns: Name of the command.
+		"""
 		return self._command
 
 # FIXME: extract to mixin?
@@ -234,6 +250,8 @@ class CommandHandler(ArgParseAttribute, _HandlerMixin):  #, _KwArgsMixin):
 		"""
 		A tuple of additional positional parameters (``*args``) passed to the attribute. These additional parameters are
 		passed without modification to :class:`~ArgumentParser`.
+
+		:returns: Tuple of positional parameters.
 		"""
 		return self._args
 
@@ -243,6 +261,8 @@ class CommandHandler(ArgParseAttribute, _HandlerMixin):  #, _KwArgsMixin):
 		"""
 		A dictionary of additional named parameters (``**kwargs``) passed to the attribute. These additional parameters are
 		passed without modification to :class:`~ArgumentParser`.
+
+		:returns: Dictionary of named parameters.
 		"""
 		return self._kwargs
 
@@ -349,12 +369,20 @@ class ArgParseHelperMixin(metaclass=ExtendedType, mixin=True):
 
 	@readonly
 	def MainParser(self) -> ArgumentParser:
-		"""Returns the main parser."""
+		"""
+		Read-only property to access the main argument parser (:attr:`_mainParser`).
+
+		:returns: The main argument parser.
+		"""
 		return self._mainParser
 
 	@readonly
 	def SubParsers(self) -> Dict[str, ArgumentParser]:
-		"""Returns the sub-parsers."""
+		"""
+		Read-only property to access the sub-parsers (:attr:`_subParser`).
+
+		:returns: Dictionary of command names and their sub-parsers.
+		"""
 		return self._subParsers
 
 

--- a/pyTooling/Attributes/__init__.py
+++ b/pyTooling/Attributes/__init__.py
@@ -151,8 +151,13 @@ class Attribute:  # (metaclass=ExtendedType, slots=True):
 		else:
 			setattr(entity, ATTRIBUTES_MEMBER_NAME,  [attribute, ])
 
-	@property
+	@readonly
 	def Scope(cls) -> AttributeScope:
+		"""
+		Read-only property to access the scope this attribute searches in (:attr:`_scope`).
+
+		:returns: The scope this attribute searches in.
+		"""
 		return cls._scope
 
 	@classmethod
@@ -242,7 +247,7 @@ class Attribute:  # (metaclass=ExtendedType, slots=True):
 
 		:param method:
 		:param includeSubClasses:
-		:return:
+		:returns:
 		:raises TypeError:
 		"""
 		if hasattr(method, ATTRIBUTES_MEMBER_NAME):
@@ -265,8 +270,18 @@ class SimpleAttribute(Attribute):
 
 	@readonly
 	def Args(self) -> Tuple[Any, ...]:
+		"""
+		Read-only property to access the positional parameters this attribute was created with (:attr:`_args`).
+
+		:returns: Tuple of positional parameters.
+		"""
 		return self._args
 
 	@readonly
 	def KwArgs(self) -> Dict[str, Any]:
+		"""
+		Read-only property to access the named parameters this attribute was created with (:attr:`_kwargs`).
+
+		:returns: Dictionary of named parameters.
+		"""
 		return self._kwargs

--- a/pyTooling/Attributes/__init__.py
+++ b/pyTooling/Attributes/__init__.py
@@ -245,9 +245,9 @@ class Attribute:  # (metaclass=ExtendedType, slots=True):
 		"""
 		Returns attached attributes of this kind for a given method.
 
-		:param method:
-		:param includeSubClasses:
-		:returns:
+		:param method:            Method to search attributes for.
+		:param includeSubClasses: If ``True``, attributes of derived attribute classes are included too.
+		:returns:                 Tuple of attached attributes of this kind.
 		:raises TypeError:
 		"""
 		if hasattr(method, ATTRIBUTES_MEMBER_NAME):

--- a/pyTooling/CLIAbstraction/Argument.py
+++ b/pyTooling/CLIAbstraction/Argument.py
@@ -109,7 +109,7 @@ class CommandLineArgument:
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal name and value.
 
-		:return:                     Formatted argument.
+		:returns:                     Formatted argument.
 		:raises NotImplementedError: This is an abstract method and must be overwritten by a subclass.
 		"""
 		raise NotImplementedError(f"Method 'AsArgument' is an abstract method and must be implemented by a subclass.")
@@ -119,7 +119,7 @@ class CommandLineArgument:
 		"""
 		Return a string representation of this argument instance.
 
-		:return:                     Argument formatted and enclosed in double quotes.
+		:returns:                     Argument formatted and enclosed in double quotes.
 		:raises NotImplementedError: This is an abstract method and must be overwritten by a subclass.
 		"""
 		raise NotImplementedError(f"Method '__str__' is an abstract method and must be implemented by a subclass.")
@@ -131,7 +131,7 @@ class CommandLineArgument:
 
 		.. note:: By default, this method is identical to :meth:`__str__`.
 
-		:return:                     Argument formatted and enclosed in double quotes.
+		:returns:                     Argument formatted and enclosed in double quotes.
 		:raises NotImplementedError: This is an abstract method and must be overwritten by a subclass.
 		"""
 		raise NotImplementedError(f"Method '__repr__' is an abstract method and must be implemented by a subclass.")
@@ -164,7 +164,7 @@ class ExecutableArgument(CommandLineArgument):
 		"""
 		Get the internal path to the wrapped executable.
 
-		:return: Internal path to the executable.
+		:returns: Internal path to the executable.
 		"""
 		return self._executable
 
@@ -188,7 +188,7 @@ class ExecutableArgument(CommandLineArgument):
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal path to the wrapped executable.
 
-		:return: Formatted argument.
+		:returns: Formatted argument.
 		"""
 		return f"{self._executable}"
 
@@ -196,7 +196,7 @@ class ExecutableArgument(CommandLineArgument):
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Argument formatted and enclosed in double quotes.
+		:returns: Argument formatted and enclosed in double quotes.
 		"""
 		return f"\"{self._executable}\""
 
@@ -225,7 +225,7 @@ class DelimiterArgument(CommandLineArgument, pattern="--"):
 		"""
 		Convert this argument instance to a string representation with proper escaping using the matching pattern.
 
-		:return: Formatted argument.
+		:returns: Formatted argument.
 		"""
 		return self._pattern
 
@@ -233,7 +233,7 @@ class DelimiterArgument(CommandLineArgument, pattern="--"):
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Argument formatted and enclosed in double quotes.
+		:returns: Argument formatted and enclosed in double quotes.
 		"""
 		return f"\"{self._pattern}\""
 
@@ -281,7 +281,7 @@ class NamedArgument(CommandLineArgument, pattern="{0}"):
 		"""
 		Get the internal name.
 
-		:return: Internal name.
+		:returns: Internal name.
 		"""
 		return self._name
 
@@ -290,7 +290,7 @@ class NamedArgument(CommandLineArgument, pattern="{0}"):
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal name.
 
-		:return:            Formatted argument.
+		:returns:            Formatted argument.
 		:raises ValueError: If internal name is None.
 		"""
 		if self._name is None:
@@ -302,7 +302,7 @@ class NamedArgument(CommandLineArgument, pattern="{0}"):
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Argument formatted and enclosed in double quotes.
+		:returns: Argument formatted and enclosed in double quotes.
 		"""
 		return f"\"{self.AsArgument()}\""
 
@@ -346,7 +346,7 @@ class ValuedArgument(CommandLineArgument, Generic[ValueT], pattern="{0}"):
 		"""
 		Get the internal value.
 
-		:return: Internal value.
+		:returns: Internal value.
 		"""
 		return self._value
 
@@ -368,7 +368,7 @@ class ValuedArgument(CommandLineArgument, Generic[ValueT], pattern="{0}"):
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal value.
 
-		:return: Formatted argument.
+		:returns: Formatted argument.
 		"""
 		return self._pattern.format(self._value)
 
@@ -376,7 +376,7 @@ class ValuedArgument(CommandLineArgument, Generic[ValueT], pattern="{0}"):
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Argument formatted and enclosed in double quotes.
+		:returns: Argument formatted and enclosed in double quotes.
 		"""
 		return f"\"{self.AsArgument()}\""
 
@@ -413,7 +413,7 @@ class NamedAndValuedArgument(NamedArgument, ValuedArgument, Generic[ValueT], pat
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal name and value.
 
-		:return:            Formatted argument.
+		:returns:            Formatted argument.
 		:raises ValueError: If internal name is None.
 		"""
 		if self._name is None:
@@ -425,7 +425,7 @@ class NamedAndValuedArgument(NamedArgument, ValuedArgument, Generic[ValueT], pat
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Argument formatted and enclosed in double quotes.
+		:returns: Argument formatted and enclosed in double quotes.
 		"""
 		return f"\"{self.AsArgument()}\""
 
@@ -494,7 +494,7 @@ class NamedTupledArgument(NamedArgument, ValuedArgument, Generic[ValueT], patter
 		Convert this argument instance to a sequence of string representations with proper escaping using the matching
 		pattern based on the internal name and value.
 
-		:return:            Formatted argument as tuple of strings.
+		:returns:            Formatted argument as tuple of strings.
 		:raises ValueError: If internal name is None.
 		"""
 		if self._name is None:
@@ -509,7 +509,7 @@ class NamedTupledArgument(NamedArgument, ValuedArgument, Generic[ValueT], patter
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Space separated sequence of arguments formatted and each enclosed in double quotes.
+		:returns: Space separated sequence of arguments formatted and each enclosed in double quotes.
 		"""
 		return " ".join([f"\"{item}\"" for item in self.AsArgument()])
 
@@ -517,7 +517,7 @@ class NamedTupledArgument(NamedArgument, ValuedArgument, Generic[ValueT], patter
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Comma separated sequence of arguments formatted and each enclosed in double quotes.
+		:returns: Comma separated sequence of arguments formatted and each enclosed in double quotes.
 		"""
 		return ", ".join([f"\"{item}\"" for item in self.AsArgument()])
 
@@ -569,7 +569,7 @@ class StringListArgument(ValuedArgument):
 		"""
 		Get the internal list of str objects.
 
-		:return: Reference to the internal list of str objects.
+		:returns: Reference to the internal list of str objects.
 		"""
 		return self._values
 
@@ -596,7 +596,7 @@ class StringListArgument(ValuedArgument):
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal value.
 
-		:return: Sequence of formatted arguments.
+		:returns: Sequence of formatted arguments.
 		"""
 		return [f"{value}" for value in self._values]
 
@@ -604,7 +604,7 @@ class StringListArgument(ValuedArgument):
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Space separated sequence of arguments formatted and each enclosed in double quotes.
+		:returns: Space separated sequence of arguments formatted and each enclosed in double quotes.
 		"""
 		return " ".join([f"\"{value}\"" for value in self.AsArgument()])
 
@@ -612,7 +612,7 @@ class StringListArgument(ValuedArgument):
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Comma separated sequence of arguments formatted and each enclosed in double quotes.
+		:returns: Comma separated sequence of arguments formatted and each enclosed in double quotes.
 		"""
 		return ", ".join([f"\"{value}\"" for value in self.AsArgument()])
 
@@ -646,7 +646,7 @@ class PathArgument(CommandLineArgument):
 		"""
 		Get the internal path object.
 
-		:return: Internal path object.
+		:returns: Internal path object.
 		"""
 		return self._path
 
@@ -670,7 +670,7 @@ class PathArgument(CommandLineArgument):
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal value.
 
-		:return: Formatted argument.
+		:returns: Formatted argument.
 		"""
 		return f"{self._path}"
 
@@ -678,7 +678,7 @@ class PathArgument(CommandLineArgument):
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Argument formatted and enclosed in double quotes.
+		:returns: Argument formatted and enclosed in double quotes.
 		"""
 		return f"\"{self._path}\""
 
@@ -714,7 +714,7 @@ class PathListArgument(CommandLineArgument):
 		"""
 		Get the internal list of path objects.
 
-		:return: Reference to the internal list of path objects.
+		:returns: Reference to the internal list of path objects.
 		"""
 		return self._paths
 
@@ -741,7 +741,7 @@ class PathListArgument(CommandLineArgument):
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal value.
 
-		:return: Sequence of formatted arguments.
+		:returns: Sequence of formatted arguments.
 		"""
 		return [f"{path}" for path in self._paths]
 
@@ -749,7 +749,7 @@ class PathListArgument(CommandLineArgument):
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Space separated sequence of arguments formatted and each enclosed in double quotes.
+		:returns: Space separated sequence of arguments formatted and each enclosed in double quotes.
 		"""
 		return " ".join([f"\"{value}\"" for value in self.AsArgument()])
 
@@ -757,6 +757,6 @@ class PathListArgument(CommandLineArgument):
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Comma separated sequence of arguments formatted and each enclosed in double quotes.
+		:returns: Comma separated sequence of arguments formatted and each enclosed in double quotes.
 		"""
 		return ", ".join([f"\"{value}\"" for value in self.AsArgument()])

--- a/pyTooling/CLIAbstraction/Argument.py
+++ b/pyTooling/CLIAbstraction/Argument.py
@@ -109,7 +109,7 @@ class CommandLineArgument:
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal name and value.
 
-		:returns:                     Formatted argument.
+		:returns:                    Formatted argument.
 		:raises NotImplementedError: This is an abstract method and must be overwritten by a subclass.
 		"""
 		raise NotImplementedError(f"Method 'AsArgument' is an abstract method and must be implemented by a subclass.")
@@ -119,7 +119,7 @@ class CommandLineArgument:
 		"""
 		Return a string representation of this argument instance.
 
-		:returns:                     Argument formatted and enclosed in double quotes.
+		:returns:                    Argument formatted and enclosed in double quotes.
 		:raises NotImplementedError: This is an abstract method and must be overwritten by a subclass.
 		"""
 		raise NotImplementedError(f"Method '__str__' is an abstract method and must be implemented by a subclass.")
@@ -131,7 +131,7 @@ class CommandLineArgument:
 
 		.. note:: By default, this method is identical to :meth:`__str__`.
 
-		:returns:                     Argument formatted and enclosed in double quotes.
+		:returns:                    Argument formatted and enclosed in double quotes.
 		:raises NotImplementedError: This is an abstract method and must be overwritten by a subclass.
 		"""
 		raise NotImplementedError(f"Method '__repr__' is an abstract method and must be implemented by a subclass.")
@@ -290,7 +290,7 @@ class NamedArgument(CommandLineArgument, pattern="{0}"):
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal name.
 
-		:returns:            Formatted argument.
+		:returns:           Formatted argument.
 		:raises ValueError: If internal name is None.
 		"""
 		if self._name is None:
@@ -413,7 +413,7 @@ class NamedAndValuedArgument(NamedArgument, ValuedArgument, Generic[ValueT], pat
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal name and value.
 
-		:returns:            Formatted argument.
+		:returns:           Formatted argument.
 		:raises ValueError: If internal name is None.
 		"""
 		if self._name is None:
@@ -494,7 +494,7 @@ class NamedTupledArgument(NamedArgument, ValuedArgument, Generic[ValueT], patter
 		Convert this argument instance to a sequence of string representations with proper escaping using the matching
 		pattern based on the internal name and value.
 
-		:returns:            Formatted argument as tuple of strings.
+		:returns:           Formatted argument as tuple of strings.
 		:raises ValueError: If internal name is None.
 		"""
 		if self._name is None:

--- a/pyTooling/CLIAbstraction/BooleanFlag.py
+++ b/pyTooling/CLIAbstraction/BooleanFlag.py
@@ -109,7 +109,7 @@ class BooleanFlag(NamedArgument, ValuedArgument):
 		"""Convert this argument instance to a string representation with proper escaping using the matching pattern based
 		on the internal name and value.
 
-		:return: Formatted argument.
+		:returns: Formatted argument.
 		:raises ValueError: If internal name is None.
 		"""
 		if self._name is None:

--- a/pyTooling/CLIAbstraction/KeyValueFlag.py
+++ b/pyTooling/CLIAbstraction/KeyValueFlag.py
@@ -111,7 +111,7 @@ class NamedKeyValuePairsArgument(NamedAndValuedArgument, pattern="{0}{1}={2}"):
 		"""
 		Get the internal value.
 
-		:return: Internal value.
+		:returns: Internal value.
 		"""
 		return self._value
 
@@ -142,7 +142,7 @@ class NamedKeyValuePairsArgument(NamedAndValuedArgument, pattern="{0}{1}={2}"):
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal name.
 
-		:return:            Formatted argument.
+		:returns:            Formatted argument.
 		:raises ValueError: If internal name is None.
 		"""
 		if self._name is None:

--- a/pyTooling/CLIAbstraction/KeyValueFlag.py
+++ b/pyTooling/CLIAbstraction/KeyValueFlag.py
@@ -142,7 +142,7 @@ class NamedKeyValuePairsArgument(NamedAndValuedArgument, pattern="{0}{1}={2}"):
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal name.
 
-		:returns:            Formatted argument.
+		:returns:           Formatted argument.
 		:raises ValueError: If internal name is None.
 		"""
 		if self._name is None:

--- a/pyTooling/CLIAbstraction/OptionalValuedFlag.py
+++ b/pyTooling/CLIAbstraction/OptionalValuedFlag.py
@@ -108,7 +108,7 @@ class OptionalValuedFlag(NamedAndValuedArgument, pattern="{0"):
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal name and optional value.
 
-		:returns:            Formatted argument.
+		:returns:           Formatted argument.
 		:raises ValueError: If internal name is None.
 		"""
 		if self._name is None:

--- a/pyTooling/CLIAbstraction/OptionalValuedFlag.py
+++ b/pyTooling/CLIAbstraction/OptionalValuedFlag.py
@@ -90,7 +90,7 @@ class OptionalValuedFlag(NamedAndValuedArgument, pattern="{0"):
 		"""
 		Get the internal value.
 
-		:return: Internal value.
+		:returns: Internal value.
 		"""
 		return self._value
 
@@ -108,7 +108,7 @@ class OptionalValuedFlag(NamedAndValuedArgument, pattern="{0"):
 		Convert this argument instance to a string representation with proper escaping using the matching pattern based on
 		the internal name and optional value.
 
-		:return:            Formatted argument.
+		:returns:            Formatted argument.
 		:raises ValueError: If internal name is None.
 		"""
 		if self._name is None:

--- a/pyTooling/CLIAbstraction/ValuedFlagList.py
+++ b/pyTooling/CLIAbstraction/ValuedFlagList.py
@@ -98,7 +98,7 @@ class ValuedFlagList(NamedAndValuedArgument, pattern="{0}={1}"):
 		"""
 		Get the internal value.
 
-		:return: Internal value.
+		:returns: Internal value.
 		"""
 		return self._value
 
@@ -129,7 +129,7 @@ class ValuedFlagList(NamedAndValuedArgument, pattern="{0}={1}"):
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Space separated sequence of arguments formatted and each enclosed in double quotes.
+		:returns: Space separated sequence of arguments formatted and each enclosed in double quotes.
 		"""
 		return " ".join([f"\"{value}\"" for value in self.AsArgument()])
 
@@ -137,7 +137,7 @@ class ValuedFlagList(NamedAndValuedArgument, pattern="{0}={1}"):
 		"""
 		Return a string representation of this argument instance.
 
-		:return: Comma separated sequence of arguments formatted and each enclosed in double quotes.
+		:returns: Comma separated sequence of arguments formatted and each enclosed in double quotes.
 		"""
 		return ", ".join([f"\"{value}\"" for value in self.AsArgument()])
 

--- a/pyTooling/CLIAbstraction/__init__.py
+++ b/pyTooling/CLIAbstraction/__init__.py
@@ -585,17 +585,29 @@ class OutputFilteredExecutable(Executable):
 	@readonly
 	def HasWarnings(self) -> bool:
 		# TODO: update doc-string
-		"""True if warnings were found while processing the output stream."""
+		"""
+		Check if warnings were found while processing the output stream.
+
+		:returns: ``True``, if at least one warning was found.
+		"""
 		return self._hasWarnings
 
 	@readonly
 	def HasErrors(self) -> bool:
 		# TODO: update doc-string
-		"""True if errors were found while processing the output stream."""
+		"""
+		Check if errors were found while processing the output stream.
+
+		:returns: ``True``, if at least one error was found.
+		"""
 		return self._hasErrors
 
 	@readonly
 	def HasFatals(self) -> bool:
 		# TODO: update doc-string
-		"""True if fatals were found while processing the output stream."""
+		"""
+		Check if fatal errors were found while processing the output stream.
+
+		:returns: ``True``, if at least one fatal error was found.
+		"""
 		return self._hasErrors

--- a/pyTooling/Cartesian2D/__init__.py
+++ b/pyTooling/Cartesian2D/__init__.py
@@ -448,7 +448,7 @@ class Size2D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		"""
 		Convert this 2D-size to a simple 2-element tuple.
 
-		:return: ``(width, height)`` tuple.
+		:returns: ``(width, height)`` tuple.
 		"""
 		return self.width, self.height
 
@@ -506,7 +506,7 @@ class LineSegment2D(Segment2D[Coordinate], Generic[Coordinate]):
 		"""
 		Read-only property to return the Euclidean distance between start and end point.
 
-		:return: Euclidean distance between start and end point
+		:returns: Euclidean distance between start and end point
 		"""
 		return sqrt((self.end.x - self.start.x) ** 2 + (self.end.x - self.start.x) ** 2)
 
@@ -521,7 +521,7 @@ class LineSegment2D(Segment2D[Coordinate], Generic[Coordinate]):
 		"""
 		Convert this 2D line segment to a 2D-offset.
 
-		:return: 2D-offset as :class:`Offset2D`
+		:returns: 2D-offset as :class:`Offset2D`
 		"""
 		return self.end - self.start
 
@@ -529,7 +529,7 @@ class LineSegment2D(Segment2D[Coordinate], Generic[Coordinate]):
 		"""
 		Convert this 2D line segment to a simple 2-element tuple of 2D-point tuples.
 
-		:return: ``((x1, y1), (x2, y2))`` tuple.
+		:returns: ``((x1, y1), (x2, y2))`` tuple.
 		"""
 		return self.start.ToTuple(), self.end.ToTuple()
 

--- a/pyTooling/Cartesian3D/__init__.py
+++ b/pyTooling/Cartesian3D/__init__.py
@@ -77,7 +77,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		"""
 		Create a new 3D-point as a copy of this 3D point.
 
-		:return: Copy of this 3D-point.
+		:returns: Copy of this 3D-point.
 
 		.. seealso::
 
@@ -92,7 +92,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		"""
 		Convert this 3D-Point to a simple 3-element tuple.
 
-		:return: ``(x, y, z)`` tuple.
+		:returns: ``(x, y, z)`` tuple.
 		"""
 		return self.x, self.y, self.z
 
@@ -101,7 +101,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		Adds a 3D-offset to this 3D-point and creates a new 3D-point.
 
 		:param other:      A 3D-offset as :class:`Offset3D` or :class:`tuple`.
-		:return:           A new 3D-point shifted by the 3D-offset.
+		:returns:           A new 3D-point shifted by the 3D-offset.
 		:raises TypeError: If parameter 'other' is not a :class:`Offset3D` or :class:`tuple`.
 		"""
 		if isinstance(other, Offset3D):
@@ -126,7 +126,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		Adds a 3D-offset to this 3D-point (inplace).
 
 		:param other:      A 3D-offset as :class:`Offset3D` or :class:`tuple`.
-		:return:           This 3D-point.
+		:returns:           This 3D-point.
 		:raises TypeError: If parameter 'other' is not a :class:`Offset3D` or :class:`tuple`.
 		"""
 		if isinstance(other, Offset3D):
@@ -149,7 +149,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		Subtract two 3D-Points from each other and create a new 3D-offset.
 
 		:param other:      A 3D-point as :class:`Point3D`.
-		:return:           A new 3D-offset representing the distance between these two points.
+		:returns:           A new 3D-offset representing the distance between these two points.
 		:raises TypeError: If parameter 'other' is not a :class:`Point3D`.
 		"""
 		if isinstance(other, Point3D):
@@ -168,7 +168,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		Subtracts a 3D-offset to this 3D-point (inplace).
 
 		:param other:      A 3D-offset as :class:`Offset3D` or :class:`tuple`.
-		:return:           This 3D-point.
+		:returns:           This 3D-point.
 		:raises TypeError: If parameter 'other' is not a :class:`Offset3D` or :class:`tuple`.
 		"""
 		if isinstance(other, Offset3D):
@@ -483,7 +483,7 @@ class Size3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		"""
 		Convert this 3D-size to a simple 3-element tuple.
 
-		:return: ``(width, height, depth)`` tuple.
+		:returns: ``(width, height, depth)`` tuple.
 		"""
 		return self.width, self.height, self.depth
 
@@ -541,7 +541,7 @@ class LineSegment3D(Segment3D[Coordinate], Generic[Coordinate]):
 		"""
 		Read-only property to return the Euclidean distance between start and end point.
 
-		:return: Euclidean distance between start and end point
+		:returns: Euclidean distance between start and end point
 		"""
 		return sqrt((self.end.x - self.start.x) ** 2 + (self.end.y - self.start.y) ** 2 + (self.end.z - self.start.z) ** 2)
 
@@ -556,7 +556,7 @@ class LineSegment3D(Segment3D[Coordinate], Generic[Coordinate]):
 		"""
 		Convert this 3D line segment to a 3D-offset.
 
-		:return: 3D-offset as :class:`Offset3D`
+		:returns: 3D-offset as :class:`Offset3D`
 		"""
 		return self.end - self.start
 
@@ -564,7 +564,7 @@ class LineSegment3D(Segment3D[Coordinate], Generic[Coordinate]):
 		"""
 		Convert this 3D line segment to a simple 2-element tuple of 3D-point tuples.
 
-		:return: ``((x1, y1, z1), (x2, y2, z2))`` tuple.
+		:returns: ``((x1, y1, z1), (x2, y2, z2))`` tuple.
 		"""
 		return self.start.ToTuple(), self.end.ToTuple()
 

--- a/pyTooling/Cartesian3D/__init__.py
+++ b/pyTooling/Cartesian3D/__init__.py
@@ -101,7 +101,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		Adds a 3D-offset to this 3D-point and creates a new 3D-point.
 
 		:param other:      A 3D-offset as :class:`Offset3D` or :class:`tuple`.
-		:returns:           A new 3D-point shifted by the 3D-offset.
+		:returns:          A new 3D-point shifted by the 3D-offset.
 		:raises TypeError: If parameter 'other' is not a :class:`Offset3D` or :class:`tuple`.
 		"""
 		if isinstance(other, Offset3D):
@@ -126,7 +126,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		Adds a 3D-offset to this 3D-point (inplace).
 
 		:param other:      A 3D-offset as :class:`Offset3D` or :class:`tuple`.
-		:returns:           This 3D-point.
+		:returns:          This 3D-point.
 		:raises TypeError: If parameter 'other' is not a :class:`Offset3D` or :class:`tuple`.
 		"""
 		if isinstance(other, Offset3D):
@@ -149,7 +149,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		Subtract two 3D-Points from each other and create a new 3D-offset.
 
 		:param other:      A 3D-point as :class:`Point3D`.
-		:returns:           A new 3D-offset representing the distance between these two points.
+		:returns:          A new 3D-offset representing the distance between these two points.
 		:raises TypeError: If parameter 'other' is not a :class:`Point3D`.
 		"""
 		if isinstance(other, Point3D):
@@ -168,7 +168,7 @@ class Point3D(Generic[Coordinate], metaclass=ExtendedType, slots=True):
 		Subtracts a 3D-offset to this 3D-point (inplace).
 
 		:param other:      A 3D-offset as :class:`Offset3D` or :class:`tuple`.
-		:returns:           This 3D-point.
+		:returns:          This 3D-point.
 		:raises TypeError: If parameter 'other' is not a :class:`Offset3D` or :class:`tuple`.
 		"""
 		if isinstance(other, Offset3D):

--- a/pyTooling/Common/__init__.py
+++ b/pyTooling/Common/__init__.py
@@ -224,10 +224,10 @@ def bind(instance, func, methodName: Nullable[str] = None):
 	or the existing name of *func*. The provided *func* should accept the
 	instance as the first argument, i.e. "self".
 
-	:param instance:
-	:param func:
-	:param methodName:
-	:returns:
+	:param instance:   Object to bind the function to.
+	:param func:       Function to bind. Its first parameter is the instance (``self``).
+	:param methodName: Optional name to bind the function as. If ``None``, the function's own name is used.
+	:returns:          The bound method.
 	"""
 	if methodName is None:
 		methodName = func.__name__
@@ -246,7 +246,7 @@ def count(iterator: Iterable) -> int:
 	.. attention:: After counting the iterable's elements, the iterable is consumed.
 
 	:param iterator: Iterable to consume and count.
-	:returns:         Number of elements in the iterable.
+	:returns:        Number of elements in the iterable.
 	"""
 	return len(list(iterator))
 
@@ -260,7 +260,7 @@ def firstElement(indexable: Union[List[_Element], Tuple[_Element, ...]]) -> _Ele
 	Returns the first element from an indexable.
 
 	:param indexable: Indexable to get the first element from.
-	:returns:          First element.
+	:returns:         First element.
 	"""
 	return indexable[0]
 
@@ -271,7 +271,7 @@ def lastElement(indexable: Union[List[_Element], Tuple[_Element, ...]]) -> _Elem
 	Returns the last element from an indexable.
 
 	:param indexable: Indexable to get the last element from.
-	:returns:          Last element.
+	:returns:         Last element.
 	"""
 	return indexable[-1]
 
@@ -282,7 +282,7 @@ def firstItem(iterable: Iterable[_Element]) -> _Element:
 	Returns the first item from an iterable.
 
 	:param iterable:    Iterable to get the first item from.
-	:returns:            First item.
+	:returns:           First item.
 	:raises ValueError: If parameter 'iterable' contains no items.
 	"""
 	i = iter(iterable)
@@ -298,7 +298,7 @@ def lastItem(iterable: Iterable[_Element]) -> _Element:
 	Returns the last item from an iterable.
 
 	:param iterable:    Iterable to get the last item from.
-	:returns:            Last item.
+	:returns:           Last item.
 	:raises ValueError: If parameter 'iterable' contains no items.
 	"""
 	i = iter(iterable)

--- a/pyTooling/Common/__init__.py
+++ b/pyTooling/Common/__init__.py
@@ -227,7 +227,7 @@ def bind(instance, func, methodName: Nullable[str] = None):
 	:param instance:
 	:param func:
 	:param methodName:
-	:return:
+	:returns:
 	"""
 	if methodName is None:
 		methodName = func.__name__
@@ -246,7 +246,7 @@ def count(iterator: Iterable) -> int:
 	.. attention:: After counting the iterable's elements, the iterable is consumed.
 
 	:param iterator: Iterable to consume and count.
-	:return:         Number of elements in the iterable.
+	:returns:         Number of elements in the iterable.
 	"""
 	return len(list(iterator))
 
@@ -260,7 +260,7 @@ def firstElement(indexable: Union[List[_Element], Tuple[_Element, ...]]) -> _Ele
 	Returns the first element from an indexable.
 
 	:param indexable: Indexable to get the first element from.
-	:return:          First element.
+	:returns:          First element.
 	"""
 	return indexable[0]
 
@@ -271,7 +271,7 @@ def lastElement(indexable: Union[List[_Element], Tuple[_Element, ...]]) -> _Elem
 	Returns the last element from an indexable.
 
 	:param indexable: Indexable to get the last element from.
-	:return:          Last element.
+	:returns:          Last element.
 	"""
 	return indexable[-1]
 
@@ -282,7 +282,7 @@ def firstItem(iterable: Iterable[_Element]) -> _Element:
 	Returns the first item from an iterable.
 
 	:param iterable:    Iterable to get the first item from.
-	:return:            First item.
+	:returns:            First item.
 	:raises ValueError: If parameter 'iterable' contains no items.
 	"""
 	i = iter(iterable)
@@ -298,7 +298,7 @@ def lastItem(iterable: Iterable[_Element]) -> _Element:
 	Returns the last item from an iterable.
 
 	:param iterable:    Iterable to get the last item from.
-	:return:            Last item.
+	:returns:            Last item.
 	:raises ValueError: If parameter 'iterable' contains no items.
 	"""
 	i = iter(iterable)

--- a/pyTooling/Configuration/JSON.py
+++ b/pyTooling/Configuration/JSON.py
@@ -74,7 +74,7 @@ class Node(Abstract_Node):
 
 		:param root:     Reference to the root node.
 		:param parent:   Reference to the parent node.
-		:param key:
+		:param key:      Key of the node within its parent.
 		:param jsonNode: Reference to the JSON node.
 		"""
 		Abstract_Node.__init__(self, root, parent)
@@ -288,7 +288,7 @@ class Dictionary(Node, Abstract_Dict):
 
 		:param root:     Reference to the root node.
 		:param parent:   Reference to the parent node.
-		:param key:
+		:param key:      Key of the node within its parent.
 		:param jsonNode: Reference to the JSON node.
 		"""
 		Node.__init__(self, root, parent, key, jsonNode)
@@ -362,7 +362,7 @@ class Sequence(Node, Abstract_Seq):
 
 		:param root:     Reference to the root node.
 		:param parent:   Reference to the parent node.
-		:param key:
+		:param key:      Key of the node within its parent.
 		:param jsonNode: Reference to the JSON node.
 		"""
 		Node.__init__(self, root, parent, key, jsonNode)

--- a/pyTooling/Configuration/YAML.py
+++ b/pyTooling/Configuration/YAML.py
@@ -78,7 +78,7 @@ class Node(Abstract_Node):
 
 		:param root:     Reference to the root node.
 		:param parent:   Reference to the parent node.
-		:param key:
+		:param key:      Key of the node within its parent.
 		:param yamlNode: Reference to the YAML node.
 		"""
 		Abstract_Node.__init__(self, root, parent)
@@ -292,7 +292,7 @@ class Dictionary(Node, Abstract_Dict):
 
 		:param root:     Reference to the root node.
 		:param parent:   Reference to the parent node.
-		:param key:
+		:param key:      Key of the node within its parent.
 		:param yamlNode: Reference to the YAML node.
 		"""
 		Node.__init__(self, root, parent, key, yamlNode)
@@ -366,7 +366,7 @@ class Sequence(Node, Abstract_Seq):
 
 		:param root:     Reference to the root node.
 		:param parent:   Reference to the parent node.
-		:param key:
+		:param key:      Key of the node within its parent.
 		:param yamlNode: Reference to the YAML node.
 		"""
 		Node.__init__(self, root, parent, key, yamlNode)

--- a/pyTooling/Configuration/__init__.py
+++ b/pyTooling/Configuration/__init__.py
@@ -139,6 +139,11 @@ class Node(metaclass=ExtendedType, slots=True):
 
 	@property
 	def Key(self) -> KeyT:
+		"""
+		Read-only property to access the node's key.
+
+		:returns: Key of the node.
+		"""
 		raise NotImplementedError()
 
 	@Key.setter

--- a/pyTooling/Dependency/Python.py
+++ b/pyTooling/Dependency/Python.py
@@ -170,14 +170,29 @@ class Distribution(metaclass=ExtendedType, slots=True):
 
 	@readonly
 	def Filename(self) -> str:
+		"""
+		Read-only property to access the distribution's filename (:attr:`_filename`).
+
+		:returns: Filename of the distribution.
+		"""
 		return self._filename
 
 	@readonly
 	def URL(self) -> URL:
+		"""
+		Read-only property to access the URL this distribution can be downloaded from (:attr:`_url`).
+
+		:returns: Download URL of the distribution.
+		"""
 		return self._url
 
 	@readonly
 	def UploadTime(self) -> datetime:
+		"""
+		Read-only property to access the time this distribution was uploaded (:attr:`_uploadTime`).
+
+		:returns: Upload time of the distribution.
+		"""
 		return self._uploadTime
 
 	def __repr__(self) -> str:
@@ -230,16 +245,31 @@ class Release(PackageVersion, LazyLoadableMixin):
 
 	@readonly
 	def Project(self) -> "Project":
+		"""
+		Read-only property to access the project this release belongs to (:attr:`_package`).
+
+		:returns: The project this release belongs to.
+		"""
 		return self._package
 
 	@lazy(LazyLoaderState.PartiallyLoaded)
 	@readonly
 	def Files(self) -> List[Distribution]:
+		"""
+		Read-only property to access the distributions published for this release (:attr:`_files`).
+
+		:returns: List of distributions.
+		"""
 		return self._files
 
 	@lazy(LazyLoaderState.PartiallyLoaded)
 	@readonly
 	def Requirements(self) -> Dict[str, List[Requirement]]:
+		"""
+		Read-only property to access the release's requirements, grouped by extra (:attr:`_requirements`).
+
+		:returns: Dictionary of extras and their requirements. Requirements without an extra are stored under ``None``.
+		"""
 		return self._requirements
 
 	def _GetPyPIEndpoint(self) -> str:
@@ -360,26 +390,51 @@ class Project(Package, LazyLoadableMixin):
 
 	@readonly
 	def PackageIndex(self) -> "PythonPackageIndex":
+		"""
+		Read-only property to access the package index this project was read from (:attr:`_storage`).
+
+		:returns: The package index this project belongs to.
+		"""
 		return self._storage
 
 	@lazy(LazyLoaderState.PartiallyLoaded)
 	@readonly
 	def URL(self) -> URL:
+		"""
+		Read-only property to access the project's URL in the package index (:attr:`_url`).
+
+		:returns: URL of the project.
+		"""
 		return self._url
 
 	@lazy(LazyLoaderState.PartiallyLoaded)
 	@readonly
 	def Releases(self) -> Dict[PythonVersion, Release]:
+		"""
+		Read-only property to access all known releases of this project (:attr:`_versions`).
+
+		:returns: Dictionary of versions and their releases.
+		"""
 		return self._versions
 
 	@lazy(LazyLoaderState.PartiallyLoaded)
 	@readonly
 	def ReleaseCount(self) -> int:
+		"""
+		Read-only property to access the number of known releases.
+
+		:returns: Number of releases.
+		"""
 		return len(self._versions)
 
 	@lazy(LazyLoaderState.PartiallyLoaded)
 	@readonly
 	def LatestRelease(self) -> Release:
+		"""
+		Read-only property to access the most recent release of this project.
+
+		:returns: The latest release.
+		"""
 		return firstValue(self._versions)
 
 	def _GetPyPIEndpoint(self) -> str:
@@ -510,18 +565,38 @@ class PythonPackageIndex(PackageStorage):
 
 	@readonly
 	def URL(self) -> URL:
+		"""
+		Read-only property to access the package index' base URL (:attr:`_url`).
+
+		:returns: Base URL of the package index.
+		"""
 		return self._url
 
 	@readonly
 	def API(self) -> URL:
+		"""
+		Read-only property to access the package index' API URL (:attr:`_api`).
+
+		:returns: API URL of the package index.
+		"""
 		return self._api
 
 	@readonly
 	def Projects(self) -> Dict[str, Project]:
+		"""
+		Read-only property to access all projects known to this package index (:attr:`_packages`).
+
+		:returns: Dictionary of project names and projects.
+		"""
 		return self._packages
 
 	@readonly
 	def ProjectCount(self) -> int:
+		"""
+		Read-only property to access the number of known projects.
+
+		:returns: Number of projects.
+		"""
 		return len(self._packages)
 
 	def _GetPyPIEndpoint(self, projectName: str) -> str:

--- a/pyTooling/Dependency/Python.py
+++ b/pyTooling/Dependency/Python.py
@@ -421,7 +421,7 @@ class Project(Package, LazyLoadableMixin):
 	@readonly
 	def ReleaseCount(self) -> int:
 		"""
-		Read-only property to access the number of known releases.
+		Read-only property to return the number of known releases.
 
 		:returns: Number of releases.
 		"""
@@ -431,7 +431,7 @@ class Project(Package, LazyLoadableMixin):
 	@readonly
 	def LatestRelease(self) -> Release:
 		"""
-		Read-only property to access the most recent release of this project.
+		Read-only property to return the most recent release of this project.
 
 		:returns: The latest release.
 		"""
@@ -593,7 +593,7 @@ class PythonPackageIndex(PackageStorage):
 	@readonly
 	def ProjectCount(self) -> int:
 		"""
-		Read-only property to access the number of known projects.
+		Read-only property to return the number of known projects.
 
 		:returns: Number of projects.
 		"""

--- a/pyTooling/Dependency/__init__.py
+++ b/pyTooling/Dependency/__init__.py
@@ -219,7 +219,7 @@ class PackageVersion(metaclass=ExtendedType, slots=True):
 
 		:param package: :class:`Package` object or name of the package.
 		:param version: :class:`~pyTooling.Versioning.SemanticVersion` object or version string or an iterable thereof.
-		:return:
+		:returns:
 		"""
 		if isinstance(package, str):
 			package = self._package._storage._packages[package]
@@ -428,6 +428,11 @@ class Package(metaclass=ExtendedType, slots=True):
 
 	@readonly
 	def VersionCount(self) -> int:
+		"""
+		Read-only property to access the number of versions this package has.
+
+		:returns: Number of versions.
+		"""
 		return len(self._versions)
 
 	def SortVersions(self) -> None:
@@ -537,6 +542,11 @@ class PackageStorage(metaclass=ExtendedType, slots=True):
 
 	@readonly
 	def PackageCount(self) -> int:
+		"""
+		Read-only property to access the number of packages in this storage.
+
+		:returns: Number of packages.
+		"""
 		return len(self._packages)
 
 	def CreatePackage(self, packageName: str) -> Package:

--- a/pyTooling/Dependency/__init__.py
+++ b/pyTooling/Dependency/__init__.py
@@ -219,7 +219,6 @@ class PackageVersion(metaclass=ExtendedType, slots=True):
 
 		:param package: :class:`Package` object or name of the package.
 		:param version: :class:`~pyTooling.Versioning.SemanticVersion` object or version string or an iterable thereof.
-		:returns:
 		"""
 		if isinstance(package, str):
 			package = self._package._storage._packages[package]
@@ -429,7 +428,7 @@ class Package(metaclass=ExtendedType, slots=True):
 	@readonly
 	def VersionCount(self) -> int:
 		"""
-		Read-only property to access the number of versions this package has.
+		Read-only property to return the number of versions this package has.
 
 		:returns: Number of versions.
 		"""
@@ -543,7 +542,7 @@ class PackageStorage(metaclass=ExtendedType, slots=True):
 	@readonly
 	def PackageCount(self) -> int:
 		"""
-		Read-only property to access the number of packages in this storage.
+		Read-only property to return the number of packages in this storage.
 
 		:returns: Number of packages.
 		"""

--- a/pyTooling/Exceptions/__init__.py
+++ b/pyTooling/Exceptions/__init__.py
@@ -101,7 +101,7 @@ class OverloadResolutionError(Exception):
 	@readonly
 	def Notes(self) -> Tuple[str, ...]:
 		"""
-		Read-only property to access warning's attached notes.
+		Read-only property to return warning's attached notes.
 
 		:returns: Attached notes.
 		"""
@@ -133,7 +133,7 @@ class ExceptionBase(Exception):
 	@readonly
 	def Notes(self) -> Tuple[str, ...]:
 		"""
-		Read-only property to access warning's attached notes.
+		Read-only property to return warning's attached notes.
 
 		:returns: Attached notes.
 		"""
@@ -183,7 +183,7 @@ class ToolingException(Exception):
 	@readonly
 	def Notes(self) -> Tuple[str, ...]:
 		"""
-		Read-only property to access warning's attached notes.
+		Read-only property to return warning's attached notes.
 
 		:returns: Attached notes.
 		"""

--- a/pyTooling/Filesystem/Docker.py
+++ b/pyTooling/Filesystem/Docker.py
@@ -61,26 +61,56 @@ class Layer(metaclass=ExtendedType):
 
 	@readonly
 	def Parent(self) -> Nullable["LayerCake"]:
+		"""
+		Read-only property to access the layer cake this layer belongs to (:attr:`_parent`).
+
+		:returns: The layer cake this layer belongs to, or ``None`` if the layer isn't part of one.
+		"""
 		return self._parent
 
 	@readonly
 	def PreviousLayer(self) -> Nullable["Layer"]:
+		"""
+		Read-only property to access the layer below this one (:attr:`_previousLayer`).
+
+		:returns: The previous layer, or ``None`` if this is the bottom layer.
+		"""
 		return self._previousLayer
 
 	@readonly
 	def NextLayer(self) -> Nullable["Layer"]:
+		"""
+		Read-only property to access the layer above this one (:attr:`_nextLayer`).
+
+		:returns: The next layer, or ``None`` if this is the top layer.
+		"""
 		return self._nextLayer
 
 	@readonly
 	def Files(self) -> List[Element[Directory]]:
+		"""
+		Read-only property to access the files contributed by this layer (:attr:`_files`).
+
+		:returns: List of files in this layer.
+		"""
 		return self._files
 
 	@readonly
 	def FileCount(self) -> int:
+		"""
+		Read-only property to access the number of files in this layer.
+
+		:returns: Number of files.
+		"""
 		return len(self._files)
 
 	@readonly
 	def Size(self) -> int:
+		"""
+		Read-only property to access the accumulated size of all files in this layer (:attr:`_size`).
+
+		:returns: Size of the layer in bytes.
+		"""
 		return self._size
 
 	def AddFile(self, element: Element) -> Set[Filename]:
@@ -130,26 +160,56 @@ class LayerCake(metaclass=ExtendedType):
 
 	@readonly
 	def Root(self) -> Root:
+		"""
+		Read-only property to access the root directory of the merged layers (:attr:`_root`).
+
+		:returns: Root directory of the layer cake.
+		"""
 		return self._root
 
 	@readonly
 	def Layers(self) -> List[Layer]:
+		"""
+		Read-only property to access all layers, bottom-most first (:attr:`_layers`).
+
+		:returns: List of layers.
+		"""
 		return self._layers
 
 	@readonly
 	def LayerCount(self) -> int:
+		"""
+		Read-only property to access the number of layers.
+
+		:returns: Number of layers.
+		"""
 		return len(self._layers)
 
 	@readonly
 	def TotalFileCount(self) -> int:
+		"""
+		Read-only property to access the number of files across all layers.
+
+		:returns: Sum of all layers' file counts.
+		"""
 		return sum(layer.FileCount for layer in self._layers)
 
 	@readonly
 	def EmptyDirectories(self) -> List[Directory]:
+		"""
+		Read-only property to access the directories that contain no files (:attr:`_emptyDirectories`).
+
+		:returns: List of empty directories.
+		"""
 		return self._emptyDirectories
 
 	@readonly
 	def EmptyDirectoryCount(self) -> int:
+		"""
+		Read-only property to access the number of empty directories.
+
+		:returns: Number of empty directories.
+		"""
 		return len(self._emptyDirectories)
 
 	@readonly

--- a/pyTooling/Filesystem/Docker.py
+++ b/pyTooling/Filesystem/Docker.py
@@ -98,7 +98,7 @@ class Layer(metaclass=ExtendedType):
 	@readonly
 	def FileCount(self) -> int:
 		"""
-		Read-only property to access the number of files in this layer.
+		Read-only property to return the number of files in this layer.
 
 		:returns: Number of files.
 		"""
@@ -179,7 +179,7 @@ class LayerCake(metaclass=ExtendedType):
 	@readonly
 	def LayerCount(self) -> int:
 		"""
-		Read-only property to access the number of layers.
+		Read-only property to return the number of layers.
 
 		:returns: Number of layers.
 		"""
@@ -188,7 +188,7 @@ class LayerCake(metaclass=ExtendedType):
 	@readonly
 	def TotalFileCount(self) -> int:
 		"""
-		Read-only property to access the number of files across all layers.
+		Read-only property to return the number of files across all layers.
 
 		:returns: Sum of all layers' file counts.
 		"""
@@ -206,7 +206,7 @@ class LayerCake(metaclass=ExtendedType):
 	@readonly
 	def EmptyDirectoryCount(self) -> int:
 		"""
-		Read-only property to access the number of empty directories.
+		Read-only property to return the number of empty directories.
 
 		:returns: Number of empty directories.
 		"""

--- a/pyTooling/Filesystem/__init__.py
+++ b/pyTooling/Filesystem/__init__.py
@@ -480,7 +480,7 @@ class Directory(Element["Directory"]):
 	@readonly
 	def Count(self) -> int:
 		"""
-		Read-only property to access the number of elements in a directory.
+		Read-only property to return the number of elements in a directory.
 
 		:returns: Number of files plus subdirectories.
 		"""
@@ -489,7 +489,7 @@ class Directory(Element["Directory"]):
 	@readonly
 	def FileCount(self) -> int:
 		"""
-		Read-only property to access the number of files in a directory.
+		Read-only property to return the number of files in a directory.
 
 		.. hint::
 
@@ -502,7 +502,7 @@ class Directory(Element["Directory"]):
 	@readonly
 	def RegularFileCount(self) -> int:
 		"""
-		Read-only property to access the number of regular files in a directory.
+		Read-only property to return the number of regular files in a directory.
 
 		:returns: Number of regular files.
 		"""
@@ -511,7 +511,7 @@ class Directory(Element["Directory"]):
 	@readonly
 	def SymbolicLinkCount(self) -> int:
 		"""
-		Read-only property to access the number of symbolic links in a directory.
+		Read-only property to return the number of symbolic links in a directory.
 
 		:returns: Number of symbolic links.
 		"""
@@ -520,7 +520,7 @@ class Directory(Element["Directory"]):
 	@readonly
 	def SubdirectoryCount(self) -> int:
 		"""
-		Read-only property to access the number of subdirectories in a directory.
+		Read-only property to return the number of subdirectories in a directory.
 
 		:returns: Number of subdirectories.
 		"""
@@ -529,7 +529,7 @@ class Directory(Element["Directory"]):
 	@readonly
 	def TotalFileCount(self) -> int:
 		"""
-		Read-only property to access the total number of files in all child hierarchy levels (recursively).
+		Read-only property to return the total number of files in all child hierarchy levels (recursively).
 
 		.. hint::
 
@@ -542,7 +542,7 @@ class Directory(Element["Directory"]):
 	@readonly
 	def TotalRegularFileCount(self) -> int:
 		"""
-		Read-only property to access the total number of regular files in all child hierarchy levels (recursively).
+		Read-only property to return the total number of regular files in all child hierarchy levels (recursively).
 
 		:returns: Total number of regular files.
 		"""
@@ -551,7 +551,7 @@ class Directory(Element["Directory"]):
 	@readonly
 	def TotalSymbolicLinkCount(self) -> int:
 		"""
-		Read-only property to access the total number of symbolic links in all child hierarchy levels (recursively).
+		Read-only property to return the total number of symbolic links in all child hierarchy levels (recursively).
 
 		:returns: Total number of symbolic links.
 		"""
@@ -560,7 +560,7 @@ class Directory(Element["Directory"]):
 	@readonly
 	def TotalSubdirectoryCount(self) -> int:
 		"""
-		Read-only property to access the total number of subdirectories in all child hierarchy levels (recursively).
+		Read-only property to return the total number of subdirectories in all child hierarchy levels (recursively).
 
 		:returns: Total number of subdirectories.
 		"""
@@ -882,7 +882,7 @@ class Filename(Element[Directory]):
 	@readonly
 	def Path(self) -> Path:
 		"""
-		Read-only property to access the filename's absolute path.
+		Read-only property to return the filename's absolute path.
 
 		The path is computed from the parent directory's path and the filename.
 
@@ -998,7 +998,7 @@ class SymbolicLink(Element[Directory]):
 	@readonly
 	def Path(self) -> Path:
 		"""
-		Read-only property to access the symbolic link's path.
+		Read-only property to return the symbolic link's path.
 
 		The path is computed from the parent directory's path and the link's name.
 
@@ -1163,7 +1163,7 @@ class Root(Directory):
 	@readonly
 	def TotalHardLinkCount(self) -> int:
 		"""
-		Read-only property to access the accumulated number of hardlinks to multiply-linked files.
+		Read-only property to return the accumulated number of hardlinks to multiply-linked files.
 
 		Every file storage object referenced by more than one directory entry contributes its number of
 		directory entries.
@@ -1175,7 +1175,7 @@ class Root(Directory):
 	@readonly
 	def TotalHardLinkCount2(self) -> int:
 		"""
-		Read-only property to access the number of file storage objects that are hardlinked.
+		Read-only property to return the number of file storage objects that are hardlinked.
 
 		In contrast to :attr:`TotalHardLinkCount`, every hardlinked file contributes ``1``, regardless of how
 		many directory entries reference it.
@@ -1187,7 +1187,7 @@ class Root(Directory):
 	@readonly
 	def TotalHardLinkCount3(self) -> int:
 		"""
-		Read-only property to access the number of file storage objects that are **not** hardlinked.
+		Read-only property to return the number of file storage objects that are **not** hardlinked.
 
 		.. attention::
 
@@ -1200,7 +1200,7 @@ class Root(Directory):
 	@readonly
 	def Size2(self) -> int:
 		"""
-		Read-only property to access the accumulated size of all hardlinked files, counted once each.
+		Read-only property to return the accumulated size of all hardlinked files, counted once each.
 
 		:returns: Sum of sizes over all files referenced by more than one directory entry.
 		"""
@@ -1209,7 +1209,7 @@ class Root(Directory):
 	@readonly
 	def Size3(self) -> int:
 		"""
-		Read-only property to access the accumulated size of all hardlinked files, counted per directory entry.
+		Read-only property to return the accumulated size of all hardlinked files, counted per directory entry.
 
 		In contrast to :attr:`Size2`, a file's size is multiplied by the number of directory entries
 		referencing it, so it reflects the size a filesystem without hardlink support would need.
@@ -1221,7 +1221,7 @@ class Root(Directory):
 	@readonly
 	def TotalUniqueFileCount(self) -> int:
 		"""
-		Read-only property to access the number of distinct file storage objects, counting hardlinks to the same content once.
+		Read-only property to return the number of distinct file storage objects, counting hardlinks to the same content once.
 
 		:returns: Number of unique files.
 		"""

--- a/pyTooling/Filesystem/__init__.py
+++ b/pyTooling/Filesystem/__init__.py
@@ -73,6 +73,11 @@ class PermissionWarning(Warning):
 
 	@readonly
 	def Path(self) -> Path:
+		"""
+		Read-only property to access the path that couldn't be read (:attr:`_path`).
+
+		:returns: The path that raised a :exc:`PermissionError`.
+		"""
 		return self._path
 
 
@@ -253,10 +258,20 @@ class Element(Base, Generic[_ParentType]):
 
 	@readonly
 	def Path(self) -> Path:
-		raise NotImplemented(f"Property 'Path' is abstract.")
+		"""
+		Read-only property to access the element's path.
+
+		:returns: Path of the element.
+		"""
+		raise NotImplementedError(f"Property 'Path' is abstract.")
 
 	@readonly
 	def LinkSources(self) -> List["SymbolicLink"]:
+		"""
+		Read-only property to access the symbolic links pointing to this element (:attr:`_linkSources`).
+
+		:returns: List of symbolic links targeting this element.
+		"""
 		return self._linkSources
 
 	def AddLinkSources(self, source: "SymbolicLink") -> None:
@@ -844,10 +859,21 @@ class Filename(Element[Directory]):
 
 	@readonly
 	def File(self) -> Nullable["File"]:
+		"""
+		Read-only property to access the file this filename is linked to (:attr:`_file`).
+
+		:returns: The linked file, or ``None`` if the filename isn't linked yet.
+		"""
 		return self._file
 
 	@readonly
 	def Size(self) -> int:
+		"""
+		Read-only property to access the size of the linked file.
+
+		:returns:                 Size of the linked file in bytes.
+		:raises ToolingException: If the filename isn't linked to a file object.
+		"""
 		if self._file is None:
 			raise ToolingException(f"Filename isn't linked to a File object.")
 
@@ -855,6 +881,14 @@ class Filename(Element[Directory]):
 
 	@readonly
 	def Path(self) -> Path:
+		"""
+		Read-only property to access the filename's absolute path.
+
+		The path is computed from the parent directory's path and the filename.
+
+		:returns:                 Absolute path of the file.
+		:raises ToolingException: If the filename has no parent object.
+		"""
 		if self._parent is None:
 			raise ToolingException(f"Filename has no parent object.")
 
@@ -963,22 +997,49 @@ class SymbolicLink(Element[Directory]):
 
 	@readonly
 	def Path(self) -> Path:
+		"""
+		Read-only property to access the symbolic link's path.
+
+		The path is computed from the parent directory's path and the link's name.
+
+		:returns: Path of the symbolic link.
+		"""
 		return self._parent.Path / self._name
 
 	@readonly
 	def Target(self) -> Path:
+		"""
+		Read-only property to access the path this symbolic link points to (:attr:`_target`).
+
+		:returns: Target path of the symbolic link.
+		"""
 		return self._target
 
 	@readonly
 	def IsConnected(self) -> bool:
+		"""
+		Check if the symbolic link was resolved to an element within the scanned filesystem (:attr:`_isConnected`).
+
+		:returns: ``True``, if the link's target was found and connected.
+		"""
 		return self._isConnected
 
 	@readonly
 	def IsBroken(self) -> Nullable[bool]:
+		"""
+		Check if the symbolic link points to a non-existing target (:attr:`_isBroken`).
+
+		:returns: ``True``, if the target doesn't exist. ``None``, if the link wasn't resolved yet.
+		"""
 		return self._isBroken
 
 	@readonly
 	def IsOutOfRange(self) -> Nullable[bool]:
+		"""
+		Check if the symbolic link points outside the scanned filesystem (:attr:`_isOutOfRange`).
+
+		:returns: ``True``, if the target lies outside the scanned root. ``None``, if the link wasn't resolved yet.
+		"""
 		return self._isOutOfRange
 
 	def __hash__(self) -> int:
@@ -1083,34 +1144,87 @@ class Root(Directory):
 
 	@readonly
 	def BrokenSymbolicLinks(self) -> List[SymbolicLink]:
+		"""
+		Read-only property to access all symbolic links with a non-existing target (:attr:`_brokenSymbolicLinks`).
+
+		:returns: List of broken symbolic links.
+		"""
 		return self._brokenSymbolicLinks
 
 	@readonly
 	def UnconnectedSymbolicLinks(self) -> List[SymbolicLink]:
+		"""
+		Read-only property to access all symbolic links that couldn't be resolved within the scanned filesystem (:attr:`_unconnectedSymbolicLinks`).
+
+		:returns: List of unconnected symbolic links.
+		"""
 		return self._unconnectedSymbolicLinks
 
 	@readonly
 	def TotalHardLinkCount(self) -> int:
+		"""
+		Read-only property to access the accumulated number of hardlinks to multiply-linked files.
+
+		Every file storage object referenced by more than one directory entry contributes its number of
+		directory entries.
+
+		:returns: Sum of directory entries over all hardlinked files.
+		"""
 		return sum(l for f in self._ids.values() if (l := len(f._parents)) > 1)
 
 	@readonly
 	def TotalHardLinkCount2(self) -> int:
+		"""
+		Read-only property to access the number of file storage objects that are hardlinked.
+
+		In contrast to :attr:`TotalHardLinkCount`, every hardlinked file contributes ``1``, regardless of how
+		many directory entries reference it.
+
+		:returns: Number of files referenced by more than one directory entry.
+		"""
 		return sum(1 for f in self._ids.values() if len(f._parents) > 1)
 
 	@readonly
 	def TotalHardLinkCount3(self) -> int:
+		"""
+		Read-only property to access the number of file storage objects that are **not** hardlinked.
+
+		.. attention::
+
+		   Despite the name, this counts files referenced by exactly *one* directory entry.
+
+		:returns: Number of files referenced by exactly one directory entry.
+		"""
 		return sum(1 for f in self._ids.values() if len(f._parents) == 1)
 
 	@readonly
 	def Size2(self) -> int:
+		"""
+		Read-only property to access the accumulated size of all hardlinked files, counted once each.
+
+		:returns: Sum of sizes over all files referenced by more than one directory entry.
+		"""
 		return sum(f._size for f in self._ids.values() if len(f._parents) > 1)
 
 	@readonly
 	def Size3(self) -> int:
+		"""
+		Read-only property to access the accumulated size of all hardlinked files, counted per directory entry.
+
+		In contrast to :attr:`Size2`, a file's size is multiplied by the number of directory entries
+		referencing it, so it reflects the size a filesystem without hardlink support would need.
+
+		:returns: Sum of sizes over all hardlinked files, weighted by their number of directory entries.
+		"""
 		return sum(f._size * len(f._parents) for f in self._ids.values() if len(f._parents) > 1)
 
 	@readonly
 	def TotalUniqueFileCount(self) -> int:
+		"""
+		Read-only property to access the number of distinct file storage objects, counting hardlinks to the same content once.
+
+		:returns: Number of unique files.
+		"""
 		return len(self._ids)
 
 	def RegisterBrokenSymbolicLink(self, symLink: SymbolicLink) -> None:

--- a/pyTooling/GenericPath/URL.py
+++ b/pyTooling/GenericPath/URL.py
@@ -140,7 +140,7 @@ class Host(RootMixIn):
 		"""
 		Create a copy of this object.
 
-		:return: A new :class:`Host` instance.
+		:returns: A new :class:`Host` instance.
 		"""
 		return self.__class__(
 			self._hostname,

--- a/pyTooling/GenericPath/__init__.py
+++ b/pyTooling/GenericPath/__init__.py
@@ -138,7 +138,7 @@ class PathMixIn(metaclass=ExtendedType, mixin=True):
 		:param root:
 		:param pathCls:    Type used to create the path.
 		:param elementCls: Type used to create the path elements.
-		:return:
+		:returns:
 		"""
 		if path.startswith(cls.ROOT_DELIMITER):
 			isAbsolute = True

--- a/pyTooling/GenericPath/__init__.py
+++ b/pyTooling/GenericPath/__init__.py
@@ -135,10 +135,10 @@ class PathMixIn(metaclass=ExtendedType, mixin=True):
 		Parses a string representation of a path and returns a path instance.
 
 		:param path:       Path to be parsed.
-		:param root:
+		:param root:       Root element the parsed path is relative to.
 		:param pathCls:    Type used to create the path.
 		:param elementCls: Type used to create the path elements.
-		:returns:
+		:returns:          A path instance of type ``pathCls``.
 		"""
 		if path.startswith(cls.ROOT_DELIMITER):
 			isAbsolute = True

--- a/pyTooling/Graph/GraphML.py
+++ b/pyTooling/Graph/GraphML.py
@@ -118,6 +118,11 @@ class Base(metaclass=ExtendedType, slots=True):
 	"""
 	@readonly
 	def HasClosingTag(self) -> bool:
+		"""
+		Check if this XML element is written with a separate closing tag.
+
+		:returns: ``True``, if the element needs a closing tag.
+		"""
 		return True
 
 	def Tag(self, indent: int = 0) -> str:
@@ -143,6 +148,11 @@ class BaseWithID(Base):
 
 	@readonly
 	def ID(self) -> str:
+		"""
+		Read-only property to access the element's unique ID (:attr:`_id`).
+
+		:returns: Unique ID of the element.
+		"""
 		return self._id
 
 
@@ -157,6 +167,11 @@ class BaseWithData(BaseWithID):
 
 	@readonly
 	def Data(self) -> List['Data']:
+		"""
+		Read-only property to access the data elements attached to this element (:attr:`_data`).
+
+		:returns: List of data elements.
+		"""
 		return self._data
 
 	def AddData(self, data: Data) -> Data:
@@ -179,18 +194,40 @@ class Key(BaseWithID):
 
 	@readonly
 	def Context(self) -> AttributeContext:
+		"""
+		Read-only property to access the context this key applies to (:attr:`_context`).
+
+		:returns: The attribute's context (graph, node, edge, ...).
+		"""
 		return self._context
 
 	@readonly
 	def AttributeName(self) -> str:
+		"""
+		Read-only property to access the name of the described attribute (:attr:`_attributeName`).
+
+		:returns: Name of the attribute.
+		"""
 		return self._attributeName
 
 	@readonly
 	def AttributeType(self) -> AttributeTypes:
+		"""
+		Read-only property to access the type of the described attribute (:attr:`_attributeType`).
+
+		:returns: Type of the attribute.
+		"""
 		return self._attributeType
 
 	@readonly
 	def HasClosingTag(self) -> bool:
+		"""
+		Check if this XML element is written with a separate closing tag.
+
+		A key is always written as a self-closing tag.
+
+		:returns: ``False``, because a key never has a closing tag.
+		"""
 		return False
 
 	def Tag(self, indent: int = 2) -> str:
@@ -213,14 +250,29 @@ class Data(Base):
 
 	@readonly
 	def Key(self) -> Key:
+		"""
+		Read-only property to access the key describing this data element (:attr:`_key`).
+
+		:returns: The key this data element refers to.
+		"""
 		return self._key
 
 	@readonly
 	def Data(self) -> Any:
+		"""
+		Read-only property to access the data element's value (:attr:`_data`).
+
+		:returns: Value of the data element.
+		"""
 		return self._data
 
 	@readonly
 	def HasClosingTag(self) -> bool:
+		"""
+		Check if this XML element is written with a separate closing tag.
+
+		:returns: ``False``, because a data element is written inline.
+		"""
 		return False
 
 	def Tag(self, indent: int = 2) -> str:
@@ -242,6 +294,11 @@ class Node(BaseWithData):
 
 	@readonly
 	def HasClosingTag(self) -> bool:
+		"""
+		Check if this XML element is written with a separate closing tag.
+
+		:returns: ``True``, if the node carries data elements, otherwise ``False``.
+		"""
 		return len(self._data) > 0
 
 	def Tag(self, indent: int = 2) -> str:
@@ -278,14 +335,29 @@ class Edge(BaseWithData):
 
 	@readonly
 	def Source(self) -> Node:
+		"""
+		Read-only property to access the edge's source node (:attr:`_source`).
+
+		:returns: Source node of the edge.
+		"""
 		return self._source
 
 	@readonly
 	def Target(self) -> Node:
+		"""
+		Read-only property to access the edge's target node (:attr:`_target`).
+
+		:returns: Target node of the edge.
+		"""
 		return self._target
 
 	@readonly
 	def HasClosingTag(self) -> bool:
+		"""
+		Check if this XML element is written with a separate closing tag.
+
+		:returns: ``True``, if the edge carries data elements, otherwise ``False``.
+		"""
 		return len(self._data) > 0
 
 	def Tag(self, indent: int = 2) -> str:
@@ -332,14 +404,29 @@ class BaseGraph(BaseWithData, mixin=True):
 
 	@readonly
 	def Subgraphs(self) -> Dict[str, 'Subgraph']:
+		"""
+		Read-only property to access the graph's subgraphs (:attr:`_subgraphs`).
+
+		:returns: Dictionary of subgraph IDs and subgraphs.
+		"""
 		return self._subgraphs
 
 	@readonly
 	def Nodes(self) -> Dict[str, Node]:
+		"""
+		Read-only property to access the graph's nodes (:attr:`_nodes`).
+
+		:returns: Dictionary of node IDs and nodes.
+		"""
 		return self._nodes
 
 	@readonly
 	def Edges(self) -> Dict[str, Edge]:
+		"""
+		Read-only property to access the graph's edges (:attr:`_edges`).
+
+		:returns: Dictionary of edge IDs and edges.
+		"""
 		return self._edges
 
 	def AddSubgraph(self, subgraph: 'Subgraph') -> 'Subgraph':
@@ -435,14 +522,29 @@ class Subgraph(Node, BaseGraph):
 
 	@readonly
 	def RootGraph(self) -> Graph:
+		"""
+		Read-only property to access the graph this subgraph is embedded in (:attr:`_root`).
+
+		:returns: The root graph.
+		"""
 		return self._root
 
 	@readonly
 	def SubgraphID(self) -> str:
+		"""
+		Read-only property to access the subgraph's ID (:attr:`_subgraphID`).
+
+		:returns: ID of the subgraph.
+		"""
 		return self._subgraphID
 
 	@readonly
 	def HasClosingTag(self) -> bool:
+		"""
+		Check if this XML element is written with a separate closing tag.
+
+		:returns: ``True``, because a subgraph always has a closing tag.
+		"""
 		return True
 
 	def AddNode(self, node: Node) -> Node:
@@ -511,10 +613,20 @@ class GraphMLDocument(Base):
 
 	@readonly
 	def Graph(self) -> BaseGraph:
+		"""
+		Read-only property to access the document's graph (:attr:`_graph`).
+
+		:returns: The graph described by this document.
+		"""
 		return self._graph
 
 	@readonly
 	def Keys(self) -> Dict[str, Key]:
+		"""
+		Read-only property to access the attribute keys declared in this document (:attr:`_keys`).
+
+		:returns: Dictionary of key IDs and keys.
+		"""
 		return self._keys
 
 	def AddKey(self, key: Key) -> Key:

--- a/pyTooling/Graph/__init__.py
+++ b/pyTooling/Graph/__init__.py
@@ -486,7 +486,7 @@ class BaseWithVertices(
 	@readonly
 	def VertexCount(self) -> int:
 		"""
-		Read-only property to access the number of vertices referenced by this object.
+		Read-only property to return the number of vertices referenced by this object.
 
 		:returns: The number of vertices this object references.
 		"""
@@ -1754,7 +1754,7 @@ class Vertex(
 
 		The tree is traversed using depths-first-search.
 
-		:returns:
+		:returns: Root node of the resulting tree, representing this vertex.
 		"""
 		visited: Set[Vertex] = set()
 		stack: List[Tuple[Node, typing_Iterator[Edge]]] = list()
@@ -2113,21 +2113,21 @@ class BaseGraph(
 
 	@readonly
 	def VertexCount(self) -> int:
-		"""Read-only property to access the number of vertices in this graph.
+		"""Read-only property to return the number of vertices in this graph.
 
 		:returns: The number of vertices in this graph."""
 		return len(self._verticesWithoutID) + len(self._verticesWithID)
 
 	@readonly
 	def EdgeCount(self) -> int:
-		"""Read-only property to access the number of edges in this graph.
+		"""Read-only property to return the number of edges in this graph.
 
 		:returns: The number of edges in this graph."""
 		return len(self._edgesWithoutID) + len(self._edgesWithID)
 
 	@readonly
 	def LinkCount(self) -> int:
-		"""Read-only property to access the number of links in this graph.
+		"""Read-only property to return the number of links in this graph.
 
 		:returns: The number of links in this graph."""
 		return len(self._linksWithoutID) + len(self._linksWithID)
@@ -2810,21 +2810,21 @@ class Graph(
 
 	@readonly
 	def SubgraphCount(self) -> int:
-		"""Read-only property to access the number of subgraphs in this graph.
+		"""Read-only property to return the number of subgraphs in this graph.
 
 		:returns: The number of subgraphs in this graph."""
 		return len(self._subgraphs)
 
 	@readonly
 	def ViewCount(self) -> int:
-		"""Read-only property to access the number of views in this graph.
+		"""Read-only property to return the number of views in this graph.
 
 		:returns: The number of views in this graph."""
 		return len(self._views)
 
 	@readonly
 	def ComponentCount(self) -> int:
-		"""Read-only property to access the number of components in this graph.
+		"""Read-only property to return the number of components in this graph.
 
 		:returns: The number of components in this graph."""
 		return len(self._components)

--- a/pyTooling/LinkedList/__init__.py
+++ b/pyTooling/LinkedList/__init__.py
@@ -334,7 +334,7 @@ class Node(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=True):
 		Optionally, this node can be included into the generated sequence.
 
 		:param includeSelf: If ``True``, include this node into the sequence, otherwise start at previous node.
-		:returns:            A sequence of nodes towards the list's first node.
+		:returns:           A sequence of nodes towards the list's first node.
 		"""
 		previousNode = self._previousNode
 
@@ -354,7 +354,7 @@ class Node(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=True):
 		Optionally, this node can be included into the generated sequence by setting.
 
 		:param includeSelf: If ``True``, include this node into the sequence, otherwise start at next node.
-		:returns:            A sequence of nodes towards the list's last node.
+		:returns:           A sequence of nodes towards the list's last node.
 		"""
 		nextNode = self._nextNode
 
@@ -448,7 +448,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 	@readonly
 	def IsEmpty(self) -> int:
 		"""
-		Read-only property to access the number of .
+		Read-only property to return the number of .
 
 		This reference is ``None`` if the node is the last node in the doubly linked list.
 
@@ -559,7 +559,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		"""
 		Remove first node from linked list.
 
-		:returns:                     First node.
+		:returns:                    First node.
 		:raises LinkedListException: If linked list is empty.
 		"""
 		if self._firstNode is None:
@@ -582,7 +582,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		"""
 		Remove last node from linked list.
 
-		:returns:                     Last node.
+		:returns:                    Last node.
 		:raises LinkedListException: If linked list is empty.
 		"""
 		if self._lastNode is None:
@@ -607,7 +607,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		Access a node in the linked list by position.
 
 		:param index:       Node position to access.
-		:returns:            Node at the given position.
+		:returns:           Node at the given position.
 		:raises ValueError: If parameter 'position' is out of range.
 
 		.. note::
@@ -770,7 +770,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		Optionally, the resulting list can be constructed in reverse order.
 
 		:param reverse: Optional parameter, if ``True`` return in reversed order, otherwise in normal order.
-		:returns:        A list (array) of this linked list's values.
+		:returns:       A list (array) of this linked list's values.
 		"""
 		if self._count == 0:
 			return []
@@ -786,7 +786,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		Optionally, the resulting tuple can be constructed in reverse order.
 
 		:param reverse: Optional parameter, if ``True`` return in reversed order, otherwise in normal order.
-		:returns:        A tuple of this linked list's values.
+		:returns:       A tuple of this linked list's values.
 		"""
 		if self._count == 0:
 			return tuple()
@@ -837,7 +837,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		Access a node's value by its index.
 
 		:param index:       Node index to access.
-		:returns:            Node's value at the given index.
+		:returns:           Node's value at the given index.
 		:raises ValueError: If parameter 'index' is out of range.
 
 		.. note::
@@ -860,7 +860,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		Remove a node at the given index.
 
 		:param index: Index of the node to remove.
-		:returns:      Removed node.
+		:returns:     Removed node.
 		"""
 		node = self.GetNodeByIndex(index)
 		node.Remove()

--- a/pyTooling/LinkedList/__init__.py
+++ b/pyTooling/LinkedList/__init__.py
@@ -155,7 +155,7 @@ class Node(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the linked list, this node belongs to.
 
-		:return: The linked list, this node is part of, or ``None``.
+		:returns: The linked list, this node is part of, or ``None``.
 		"""
 		return self._linkedList
 
@@ -166,7 +166,7 @@ class Node(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=True):
 
 		This reference is ``None`` if the node is the first node in the doubly linked list.
 
-		:return: The node before the current node or ``None``.
+		:returns: The node before the current node or ``None``.
 		"""
 		return self._previousNode
 
@@ -177,7 +177,7 @@ class Node(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=True):
 
 		This reference is ``None`` if the node is the last node in the doubly linked list.
 
-		:return: The node after the current node or ``None``.
+		:returns: The node after the current node or ``None``.
 		"""
 		return self._nextNode
 
@@ -188,7 +188,7 @@ class Node(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=True):
 
 		The key can be a scalar or a reference to an object.
 
-		:return: The node's key.
+		:returns: The node's key.
 		"""
 		return self._key
 
@@ -203,7 +203,7 @@ class Node(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=True):
 
 		The data can be a scalar or a reference to an object.
 
-		:return: The node's value.
+		:returns: The node's value.
 		"""
 		return self._value
 
@@ -334,7 +334,7 @@ class Node(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=True):
 		Optionally, this node can be included into the generated sequence.
 
 		:param includeSelf: If ``True``, include this node into the sequence, otherwise start at previous node.
-		:return:            A sequence of nodes towards the list's first node.
+		:returns:            A sequence of nodes towards the list's first node.
 		"""
 		previousNode = self._previousNode
 
@@ -354,7 +354,7 @@ class Node(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=True):
 		Optionally, this node can be included into the generated sequence by setting.
 
 		:param includeSelf: If ``True``, include this node into the sequence, otherwise start at next node.
-		:return:            A sequence of nodes towards the list's last node.
+		:returns:            A sequence of nodes towards the list's last node.
 		"""
 		nextNode = self._nextNode
 
@@ -452,7 +452,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 
 		This reference is ``None`` if the node is the last node in the doubly linked list.
 
-		:return: ``True`` if linked list is empty, otherwise ``False``
+		:returns: ``True`` if linked list is empty, otherwise ``False``
 		"""
 		return self._count == 0
 
@@ -461,7 +461,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		"""
 		Read-only property to access the number of nodes in the linked list.
 
-		:return: Number of nodes.
+		:returns: Number of nodes.
 		"""
 		return self._count
 
@@ -472,7 +472,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 
 		In case the list is empty, ``None`` is returned.
 
-		:return: First node.
+		:returns: First node.
 		"""
 		return self._firstNode
 
@@ -483,7 +483,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 
 		In case the list is empty, ``None`` is returned.
 
-		:return: Last node.
+		:returns: Last node.
 		"""
 		return self._lastNode
 
@@ -559,7 +559,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		"""
 		Remove first node from linked list.
 
-		:return:                     First node.
+		:returns:                     First node.
 		:raises LinkedListException: If linked list is empty.
 		"""
 		if self._firstNode is None:
@@ -582,7 +582,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		"""
 		Remove last node from linked list.
 
-		:return:                     Last node.
+		:returns:                     Last node.
 		:raises LinkedListException: If linked list is empty.
 		"""
 		if self._lastNode is None:
@@ -607,7 +607,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		Access a node in the linked list by position.
 
 		:param index:       Node position to access.
-		:return:            Node at the given position.
+		:returns:            Node at the given position.
 		:raises ValueError: If parameter 'position' is out of range.
 
 		.. note::
@@ -737,7 +737,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		"""
 		Return a generator iterating forward from list's first node to list's last node.
 
-		:return: A sequence of nodes towards the list's last node.
+		:returns: A sequence of nodes towards the list's last node.
 		"""
 		if self._firstNode is None:
 			return
@@ -752,7 +752,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		"""
 		Return a generator iterating backward from list's last node to list's first node.
 
-		:return: A sequence of nodes towards the list's first node.
+		:returns: A sequence of nodes towards the list's first node.
 		"""
 		if self._lastNode is None:
 			return
@@ -770,7 +770,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		Optionally, the resulting list can be constructed in reverse order.
 
 		:param reverse: Optional parameter, if ``True`` return in reversed order, otherwise in normal order.
-		:return:        A list (array) of this linked list's values.
+		:returns:        A list (array) of this linked list's values.
 		"""
 		if self._count == 0:
 			return []
@@ -786,7 +786,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		Optionally, the resulting tuple can be constructed in reverse order.
 
 		:param reverse: Optional parameter, if ``True`` return in reversed order, otherwise in normal order.
-		:return:        A tuple of this linked list's values.
+		:returns:        A tuple of this linked list's values.
 		"""
 		if self._count == 0:
 			return tuple()
@@ -837,7 +837,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		Access a node's value by its index.
 
 		:param index:       Node index to access.
-		:return:            Node's value at the given index.
+		:returns:            Node's value at the given index.
 		:raises ValueError: If parameter 'index' is out of range.
 
 		.. note::
@@ -860,7 +860,7 @@ class LinkedList(Generic[_NodeKey, _NodeValue], metaclass=ExtendedType, slots=Tr
 		Remove a node at the given index.
 
 		:param index: Index of the node to remove.
-		:return:      Removed node.
+		:returns:      Removed node.
 		"""
 		node = self.GetNodeByIndex(index)
 		node.Remove()

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -102,6 +102,22 @@ class DuplicateFieldInSlotsError(ExtendedTypeError):
 
 
 @export
+class ShadowedSlotWarning(Warning):
+	"""
+	A class member shadows a slot inherited from a base-class or contributed by a mixin-class.
+
+	An assignment without a type annotation stays a class attribute, which hides the slot's descriptor. Reading the field
+	still works, but assigning it on an instance raises an :exc:`AttributeError`.
+
+	.. important::
+
+	   This is a warning rather than an exception, because the pattern is harmless as long as the field is never assigned
+	   per instance - a base-class declaring the field and derived classes supplying a constant is a common idiom.
+	   Annotating it as :class:`~typing.ClassVar` expresses that intent and silences the warning.
+	"""
+
+
+@export
 class UnannotatedFieldWarning(Warning):
 	"""
 	A class declares a field that was assigned in the class body without a type annotation.
@@ -839,16 +855,30 @@ class ExtendedType(type):
 			# A member assigned in the class body without a type annotation stays a class attribute. If it carries the name
 			# of a slot, that class attribute shadows the slot's descriptor and the field becomes read-only on instances.
 			# Report it here instead of letting the first assignment fail with a bare AttributeError.
-			shadowedSlots = {**inheritedSlottedFields, **{fieldName: None for fieldName in mixinSlots}}
-			for fieldName in shadowedSlots.keys() & members.keys():
+			# A slot contributed by a mixin-class is materialized in this class' own __slots__, so Python itself rejects the
+			# class body with "ValueError: '<name>' in __slots__ conflicts with class variable". Report it first, with a
+			# message that names the cause.
+			for fieldName in set(mixinSlots) & members.keys():
 				ex = DuplicateFieldInSlotsError(f"Slot '{fieldName}' is shadowed by a class member in class '{className}'.")
-				if (baseClass := shadowedSlots[fieldName]) is not None:
-					ex.add_note(f"Slot '{fieldName}' is declared in base-class '{baseClass.__module__}.{baseClass.__name__}'.")
-				else:
-					ex.add_note(f"Slot '{fieldName}' is contributed by a mixin-class.")
-				ex.add_note(f"An assignment without a type annotation creates a class attribute, which hides the slot's descriptor.")
+				ex.add_note(f"Slot '{fieldName}' is contributed by a mixin-class and materialized in this class' '__slots__'.")
+				ex.add_note(f"Python doesn't allow a name to be listed in '__slots__' and assigned in the class body.")
 				ex.add_note(f"Annotate it as 'ClassVar[...]' to declare a class variable, or remove the assignment.")
 				raise ex
+
+			# A slot inherited from a base-class isn't in this class' __slots__, so Python accepts the class body. The class
+			# attribute merely hides the inherited descriptor: reading works, assigning on an instance doesn't. That's
+			# harmless as long as the field is never assigned per instance, so it's reported as a warning.
+			for fieldName in inheritedSlottedFields.keys() & members.keys():
+				baseClass = inheritedSlottedFields[fieldName]
+				WarningCollector.Raise(
+					ShadowedSlotWarning(f"Slot '{fieldName}' is shadowed by a class member in class '{className}'."),
+					notes=(
+						f"Slot '{fieldName}' is declared in base-class '{baseClass.__module__}.{baseClass.__name__}'.",
+						f"An assignment without a type annotation creates a class attribute, which hides the slot's descriptor.",
+						f"Reading the field works, but assigning it on an instance raises an AttributeError.",
+						f"Annotate it as 'ClassVar[...]' to declare a class variable, or remove the assignment.",
+					)
+				)
 		else:
 			# When adding annotated fields to slottedFields, check if name was not used in inheritance hierarchy.
 			for fieldName, typeAnnotation in annotations.items():

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -545,7 +545,7 @@ class ExtendedType(type):
 			"""
 
 			:param predicate:
-			:return:
+			:returns:
 			:raises ValueError:
 			:raises ValueError:
 			"""
@@ -601,7 +601,7 @@ class ExtendedType(type):
 		:param newClass:    Newly created class instance.
 		:param baseClasses: The tuple of :term:`base-classes <base-class>` the class is derived from.
 		:param members:     Members of the new class.
-		:return:
+		:returns:
 		"""
 		from pyTooling.Attributes import Attribute
 

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -544,10 +544,10 @@ class ExtendedType(type):
 		def GetMethodsWithAttributes(self, predicate: Nullable[TAttributeFilter[TAttr]] = None) -> Dict[Callable, Tuple["Attribute", ...]]:
 			"""
 
-			:param predicate:
-			:returns:
-			:raises ValueError:
-			:raises ValueError:
+			:param predicate:   An attribute class, an iterable of attribute classes, or ``None`` to accept every attribute.
+			:returns:           Dictionary of methods and the matching attributes attached to them.
+			:raises ValueError: If an element of parameter 'predicate' is not a sub-class of :class:`~pyTooling.Attributes.Attribute`.
+			:raises ValueError: If parameter 'predicate' is neither an attribute class nor an iterable of those.
 			"""
 			from pyTooling.Attributes import Attribute
 
@@ -601,7 +601,7 @@ class ExtendedType(type):
 		:param newClass:    Newly created class instance.
 		:param baseClasses: The tuple of :term:`base-classes <base-class>` the class is derived from.
 		:param members:     Members of the new class.
-		:returns:
+		:returns:           A 2-tuple of all methods and those methods carrying at least one attribute.
 		"""
 		from pyTooling.Attributes import Attribute
 

--- a/pyTooling/MetaClasses/__init__.py
+++ b/pyTooling/MetaClasses/__init__.py
@@ -102,22 +102,6 @@ class DuplicateFieldInSlotsError(ExtendedTypeError):
 
 
 @export
-class ShadowedSlotWarning(Warning):
-	"""
-	A class member shadows a slot inherited from a base-class or contributed by a mixin-class.
-
-	An assignment without a type annotation stays a class attribute, which hides the slot's descriptor. Reading the field
-	still works, but assigning it on an instance raises an :exc:`AttributeError`.
-
-	.. important::
-
-	   This is a warning rather than an exception, because the pattern is harmless as long as the field is never assigned
-	   per instance - a base-class declaring the field and derived classes supplying a constant is a common idiom.
-	   Annotating it as :class:`~typing.ClassVar` expresses that intent and silences the warning.
-	"""
-
-
-@export
 class UnannotatedFieldWarning(Warning):
 	"""
 	A class declares a field that was assigned in the class body without a type annotation.
@@ -855,30 +839,18 @@ class ExtendedType(type):
 			# A member assigned in the class body without a type annotation stays a class attribute. If it carries the name
 			# of a slot, that class attribute shadows the slot's descriptor and the field becomes read-only on instances.
 			# Report it here instead of letting the first assignment fail with a bare AttributeError.
-			# A slot contributed by a mixin-class is materialized in this class' own __slots__, so Python itself rejects the
-			# class body with "ValueError: '<name>' in __slots__ conflicts with class variable". Report it first, with a
-			# message that names the cause.
-			for fieldName in set(mixinSlots) & members.keys():
+			shadowedSlots = {**inheritedSlottedFields, **{fieldName: None for fieldName in mixinSlots}}
+			for fieldName in shadowedSlots.keys() & members.keys():
 				ex = DuplicateFieldInSlotsError(f"Slot '{fieldName}' is shadowed by a class member in class '{className}'.")
-				ex.add_note(f"Slot '{fieldName}' is contributed by a mixin-class and materialized in this class' '__slots__'.")
-				ex.add_note(f"Python doesn't allow a name to be listed in '__slots__' and assigned in the class body.")
+				if (baseClass := shadowedSlots[fieldName]) is not None:
+					ex.add_note(f"Slot '{fieldName}' is declared in base-class '{baseClass.__module__}.{baseClass.__name__}'.")
+					ex.add_note(f"An assignment without a type annotation creates a class attribute, which hides the slot's descriptor.")
+					ex.add_note(f"Reading the field works, but assigning it on an instance raises an AttributeError.")
+				else:
+					ex.add_note(f"Slot '{fieldName}' is contributed by a mixin-class and materialized in this class' '__slots__'.")
+					ex.add_note(f"Python doesn't allow a name to be listed in '__slots__' and assigned in the class body.")
 				ex.add_note(f"Annotate it as 'ClassVar[...]' to declare a class variable, or remove the assignment.")
 				raise ex
-
-			# A slot inherited from a base-class isn't in this class' __slots__, so Python accepts the class body. The class
-			# attribute merely hides the inherited descriptor: reading works, assigning on an instance doesn't. That's
-			# harmless as long as the field is never assigned per instance, so it's reported as a warning.
-			for fieldName in inheritedSlottedFields.keys() & members.keys():
-				baseClass = inheritedSlottedFields[fieldName]
-				WarningCollector.Raise(
-					ShadowedSlotWarning(f"Slot '{fieldName}' is shadowed by a class member in class '{className}'."),
-					notes=(
-						f"Slot '{fieldName}' is declared in base-class '{baseClass.__module__}.{baseClass.__name__}'.",
-						f"An assignment without a type annotation creates a class attribute, which hides the slot's descriptor.",
-						f"Reading the field works, but assigning it on an instance raises an AttributeError.",
-						f"Annotate it as 'ClassVar[...]' to declare a class variable, or remove the assignment.",
-					)
-				)
 		else:
 			# When adding annotated fields to slottedFields, check if name was not used in inheritance hierarchy.
 			for fieldName, typeAnnotation in annotations.items():

--- a/pyTooling/Packaging/__init__.py
+++ b/pyTooling/Packaging/__init__.py
@@ -238,37 +238,65 @@ class VersionInformation(metaclass=ExtendedType, slots=True):
 
 	@readonly
 	def Author(self) -> str:
-		"""Name(s) of the package author(s)."""
+		"""
+		Read-only property to access the name(s) of the package author(s) (:attr:`_author`).
+
+		:returns: Name(s) of the package author(s).
+		"""
 		return self._author
 
 	@readonly
 	def Copyright(self) -> str:
-		"""Copyright information."""
+		"""
+		Read-only property to access the package's copyright information (:attr:`_copyright`).
+
+		:returns: Copyright information.
+		"""
 		return self._copyright
 
 	@readonly
 	def Description(self) -> str:
-		"""Package description text."""
+		"""
+		Read-only property to access the package description (:attr:`_description`).
+
+		:returns: Package description text.
+		"""
 		return self._description
 
 	@readonly
 	def Email(self) -> str:
-		"""Email address of the author."""
+		"""
+		Read-only property to access the author's email address (:attr:`_email`).
+
+		:returns: Email address of the author.
+		"""
 		return self._email
 
 	@readonly
 	def Keywords(self) -> List[str]:
-		"""List of keywords."""
+		"""
+		Read-only property to access the package's keywords (:attr:`_keywords`).
+
+		:returns: List of keywords.
+		"""
 		return self._keywords
 
 	@readonly
 	def License(self) -> str:
-		"""License name."""
+		"""
+		Read-only property to access the package's license (:attr:`_license`).
+
+		:returns: License name.
+		"""
 		return self._license
 
 	@readonly
 	def Version(self) -> str:
-		"""Version number."""
+		"""
+		Read-only property to access the package's version number (:attr:`_version`).
+
+		:returns: Version number.
+		"""
 		return self._version
 
 	def __str__(self) -> str:

--- a/pyTooling/Platform/__init__.py
+++ b/pyTooling/Platform/__init__.py
@@ -340,6 +340,11 @@ class Platform(metaclass=ExtendedType, singleton=True, slots=True):
 
 	@readonly
 	def HostOperatingSystem(self) -> Platforms:
+		"""
+		Read-only property to access the host's operating system.
+
+		:returns: The operating system portion of the platform flags.
+		"""
 		return self._platform & Platforms.OperatingSystem
 
 	@readonly

--- a/pyTooling/Platform/__init__.py
+++ b/pyTooling/Platform/__init__.py
@@ -307,7 +307,7 @@ class Platform(metaclass=ExtendedType, singleton=True, slots=True):
 	@readonly
 	def PythonImplementation(self) -> PythonImplementation:
 		"""
-		Read-only property to return the :class:`PythonImplementation` of the current interpreter.
+		Read-only property to access the :class:`PythonImplementation` of the current interpreter.
 
 		:returns: Python implementation of the current interpreter.
 		"""
@@ -332,7 +332,7 @@ class Platform(metaclass=ExtendedType, singleton=True, slots=True):
 	@readonly
 	def PythonVersion(self) -> PythonVersion:
 		"""
-		Read-only property to return the :class:`pyTooling.Versioning.PythonVersion` of the current interpreter.
+		Read-only property to access the :class:`pyTooling.Versioning.PythonVersion` of the current interpreter.
 
 		:returns: Python version of the current interpreter.
 		"""
@@ -341,7 +341,7 @@ class Platform(metaclass=ExtendedType, singleton=True, slots=True):
 	@readonly
 	def HostOperatingSystem(self) -> Platforms:
 		"""
-		Read-only property to access the host's operating system.
+		Read-only property to return the host's operating system.
 
 		:returns: The operating system portion of the platform flags.
 		"""

--- a/pyTooling/Stopwatch/__init__.py
+++ b/pyTooling/Stopwatch/__init__.py
@@ -290,7 +290,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Read-only property returning the name of the stopwatch.
 
-		:return: Name of the stopwatch.
+		:returns: Name of the stopwatch.
 		"""
 		return self._name
 
@@ -299,7 +299,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Read-only property returning the IsStarted state of the stopwatch.
 
-		:return: True, if stopwatch was started.
+		:returns: True, if stopwatch was started.
 		"""
 		return self._startTime is not None and self._stopTime is None
 
@@ -308,7 +308,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Read-only property returning the IsRunning state of the stopwatch.
 
-		:return: True, if stopwatch was started and is currently not paused.
+		:returns: True, if stopwatch was started and is currently not paused.
 		"""
 		return self._startTime is not None and self._resumeTime is not None
 
@@ -317,7 +317,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Read-only property returning the IsPaused state of the stopwatch.
 
-		:return: True, if stopwatch was started and is currently paused.
+		:returns: True, if stopwatch was started and is currently paused.
 		"""
 		return self._startTime is not None and self._pauseTime is not None
 
@@ -326,7 +326,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Read-only property returning the IsStopped state of the stopwatch.
 
-		:return: True, if stopwatch was stopped.
+		:returns: True, if stopwatch was stopped.
 		"""
 		return self._stopTime is not None
 
@@ -335,7 +335,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Read-only property returning the absolute time when the stopwatch was started.
 
-		:return: The time when the stopwatch was started, otherwise None.
+		:returns: The time when the stopwatch was started, otherwise None.
 		"""
 		return self._beginTime
 
@@ -344,7 +344,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Read-only property returning the absolute time when the stopwatch was stopped.
 
-		:return: The time when the stopwatch was stopped, otherwise None.
+		:returns: The time when the stopwatch was stopped, otherwise None.
 		"""
 		return self._endTime
 
@@ -353,7 +353,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Read-only property checking if split times have been taken.
 
-		:return: True, if split times have been taken.
+		:returns: True, if split times have been taken.
 		"""
 		return len(self._splits) > 1
 
@@ -362,7 +362,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Read-only property returning the number of split times.
 
-		:return: Number of split times.
+		:returns: Number of split times.
 		"""
 		return len(self._splits)
 
@@ -371,7 +371,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Read-only property returning the number of active split times.
 
-		:return: Number of active split times.
+		:returns: Number of active split times.
 
 		.. warning::
 
@@ -387,7 +387,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Read-only property returning the number of active split times.
 
-		:return: Number of active split times.
+		:returns: Number of active split times.
 
 		.. warning::
 
@@ -405,7 +405,7 @@ class Stopwatch(SlottedObject):
 
 		If the stopwatch is currently running, the duration since start or last resume operation will be included.
 
-		:return: Duration of all active split times in seconds. If the stopwatch was never started, the return value will
+		:returns: Duration of all active split times in seconds. If the stopwatch was never started, the return value will
 		         be 0.0.
 		"""
 		if self._startTime is None:
@@ -421,7 +421,7 @@ class Stopwatch(SlottedObject):
 
 		If the stopwatch is currently paused, the duration since last pause operation will be included.
 
-		:return: Duration of all inactive split times in seconds. If the stopwatch was never started, the return value will
+		:returns: Duration of all inactive split times in seconds. If the stopwatch was never started, the return value will
 		         be 0.0.
 		"""
 		if self._startTime is None:
@@ -437,7 +437,7 @@ class Stopwatch(SlottedObject):
 
 		If the stopwatch is not yet stopped, the duration from start to now is returned.
 
-		:return: Duration since stopwatch was started in seconds. If the stopwatch was never started, the return value will
+		:returns: Duration since stopwatch was started in seconds. If the stopwatch was never started, the return value will
 		         be 0.0.
 		"""
 		if self._startTime is None:
@@ -464,7 +464,7 @@ class Stopwatch(SlottedObject):
 
 		An unstarted stopwatch will be started. A paused stopwatch will be resumed.
 
-		:return: The stopwatch itself.
+		:returns: The stopwatch itself.
 		"""
 		if self._startTime is None:           # start stopwatch
 			self._beginTime = datetime.now()
@@ -527,7 +527,7 @@ class Stopwatch(SlottedObject):
 		"""
 		Implementation of ``len(...)`` to return the number of split times.
 
-		:return: Number of split times.
+		:returns: Number of split times.
 		"""
 		return len(self._splits)
 
@@ -536,7 +536,7 @@ class Stopwatch(SlottedObject):
 		Implementation of ``split = object[i]`` to return the i-th split time.
 
 		:param index:     Index to access the i-th split time.
-		:return:          i-th split time as a tuple of: |br|
+		:returns:          i-th split time as a tuple of: |br|
 		                  (1) delta time to the previous stopwatch operation and |br|
 		                  (2) a boolean indicating if the split was an activity (true) or inactivity (false).
 		:raises KeyError: If index *i* doesn't exist.
@@ -549,7 +549,7 @@ class Stopwatch(SlottedObject):
 
 		If the stopwatch is not stopped yet, the last split won't be included.
 
-		:return: Iterator of split time tuples of: |br|
+		:returns: Iterator of split time tuples of: |br|
 		         (1) delta time to the previous stopwatch operation and |br|
 		         (2) a boolean indicating if the split was an activity (true) or inactivity (false).
 		"""

--- a/pyTooling/Stopwatch/__init__.py
+++ b/pyTooling/Stopwatch/__init__.py
@@ -536,7 +536,7 @@ class Stopwatch(SlottedObject):
 		Implementation of ``split = object[i]`` to return the i-th split time.
 
 		:param index:     Index to access the i-th split time.
-		:returns:          i-th split time as a tuple of: |br|
+		:returns:         i-th split time as a tuple of: |br|
 		                  (1) delta time to the previous stopwatch operation and |br|
 		                  (2) a boolean indicating if the split was an activity (true) or inactivity (false).
 		:raises KeyError: If index *i* doesn't exist.

--- a/pyTooling/Streaming/__init__.py
+++ b/pyTooling/Streaming/__init__.py
@@ -69,7 +69,7 @@ def QueueReader(queue: ThreadSafeQueue[Nullable[QueueItem]]) -> Iterator[QueueIt
 	``None`` is used as the end-of-stream marker.
 
 	:param queue: The queue to read from.
-	:returns:      An iterator over the items from the queue.
+	:returns:     An iterator over the items from the queue.
 	"""
 	while True:
 		if (item := queue.get()) is None:

--- a/pyTooling/Streaming/__init__.py
+++ b/pyTooling/Streaming/__init__.py
@@ -69,7 +69,7 @@ def QueueReader(queue: ThreadSafeQueue[Nullable[QueueItem]]) -> Iterator[QueueIt
 	``None`` is used as the end-of-stream marker.
 
 	:param queue: The queue to read from.
-	:return:      An iterator over the items from the queue.
+	:returns:      An iterator over the items from the queue.
 	"""
 	while True:
 		if (item := queue.get()) is None:

--- a/pyTooling/TerminalUI/__init__.py
+++ b/pyTooling/TerminalUI/__init__.py
@@ -260,7 +260,7 @@ class TerminalBaseApplication(metaclass=ExtendedType, slots=True, singleton=True
 		Call `ioctl` with ``TIOCGWINSZ`` (GetWindowsSize) for the given file descriptor.
 
 		:param fd: File descriptor
-		:return:
+		:returns:
 		"""
 		try:
 			from array import array
@@ -759,7 +759,11 @@ class ILineTerminal:
 
 	@readonly
 	def Terminal(self) -> TerminalBaseApplication:
-		"""Return the local terminal instance."""
+		"""
+		Read-only property to access the local terminal instance (:attr:`_terminal`).
+
+		:returns: The terminal instance, or ``None`` if no terminal is attached.
+		"""
 		return self._terminal
 
 	def WriteLine(self, line: Line, condition: bool = True) -> bool:
@@ -1059,27 +1063,47 @@ class TerminalApplication(TerminalBaseApplication):  #, ILineTerminal):
 
 	@readonly
 	def Verbose(self) -> bool:
-		"""Returns true, if verbose messages are enabled."""
+		"""
+		Check if verbose messages are enabled.
+
+		:returns: ``True``, if verbose messages are written.
+		"""
 		return self._verbose
 
 	@readonly
 	def Debug(self) -> bool:
-		"""Returns true, if debug messages are enabled."""
+		"""
+		Check if debug messages are enabled.
+
+		:returns: ``True``, if debug messages are written.
+		"""
 		return self._debug
 
 	@readonly
 	def Silent(self) -> bool:
-		"""Returns true, if silent mode is enabled."""
+		"""
+		Check if silent mode is enabled.
+
+		:returns: ``True``, if silent mode is enabled.
+		"""
 		return self._silent
 
 	@readonly
 	def Quiet(self) -> bool:
-		"""Returns true, if quiet mode is enabled."""
+		"""
+		Check if quiet mode is enabled.
+
+		:returns: ``True``, if quiet mode is enabled.
+		"""
 		return self._quiet
 
 	@property
 	def LogLevel(self) -> Severity:
-		"""Return the current minimal severity level for writing."""
+		"""
+		Read-only property to access the minimal severity level a message needs to be written (:attr:`_writeLevel`).
+
+		:returns: The current minimal severity level.
+		"""
 		return self._writeLevel
 
 	@LogLevel.setter
@@ -1089,6 +1113,11 @@ class TerminalApplication(TerminalBaseApplication):  #, ILineTerminal):
 
 	@property
 	def BaseIndent(self) -> int:
+		"""
+		Read-only property to access the base indentation level of written messages (:attr:`_baseIndent`).
+
+		:returns: Base indentation level.
+		"""
 		return self._baseIndent
 
 	@BaseIndent.setter
@@ -1100,7 +1129,7 @@ class TerminalApplication(TerminalBaseApplication):  #, ILineTerminal):
 		"""
 		Read-only property to access the number of counted warnings.
 
-		:return: Number of warnings.
+		:returns: Number of warnings.
 		"""
 		return self._warningCount
 
@@ -1109,7 +1138,7 @@ class TerminalApplication(TerminalBaseApplication):  #, ILineTerminal):
 		"""
 		Read-only property to access the number of counted critical warnings.
 
-		:return: Number of critical warnings.
+		:returns: Number of critical warnings.
 		"""
 		return self._criticalWarningCount
 
@@ -1118,7 +1147,7 @@ class TerminalApplication(TerminalBaseApplication):  #, ILineTerminal):
 		"""
 		Read-only property to access the number of counted errors.
 
-		:return: Number of errors.
+		:returns: Number of errors.
 		"""
 		return self._errorCount
 

--- a/pyTooling/TerminalUI/__init__.py
+++ b/pyTooling/TerminalUI/__init__.py
@@ -259,8 +259,8 @@ class TerminalBaseApplication(metaclass=ExtendedType, slots=True, singleton=True
 
 		Call `ioctl` with ``TIOCGWINSZ`` (GetWindowsSize) for the given file descriptor.
 
-		:param fd: File descriptor
-		:returns:
+		:param fd: File descriptor to query.
+		:returns:  A 2-tuple of terminal width and height, or ``None`` if the size couldn't be determined.
 		"""
 		try:
 			from array import array
@@ -727,7 +727,7 @@ class Line(metaclass=ExtendedType, slots=True):
 	@readonly
 	def AppendLinebreak(self) -> bool:
 		"""
-		Read-only property to return if a linebreak is added after the line's message.
+		Read-only property to access if a linebreak is added after the line's message.
 
 		:returns: True, if a linebreak should be added.
 		"""

--- a/pyTooling/Tracing/__init__.py
+++ b/pyTooling/Tracing/__init__.py
@@ -354,7 +354,7 @@ class Span(metaclass=ExtendedType, slots=True):
 
 		If the span is not yet stopped, the duration from start to now is returned.
 
-		:returns:                  Duration since span was started in seconds.
+		:returns:                 Duration since span was started in seconds.
 		:raises TracingException: When span was never started.
 		"""
 		if self._startTime is None:

--- a/pyTooling/Tracing/__init__.py
+++ b/pyTooling/Tracing/__init__.py
@@ -289,7 +289,7 @@ class Span(metaclass=ExtendedType, slots=True):
 		"""
 		Return the number of sub-spans within this span.
 
-		:return: Number of nested spans.
+		:returns: Number of nested spans.
 		"""
 		return len(self._spans)
 
@@ -316,7 +316,7 @@ class Span(metaclass=ExtendedType, slots=True):
 		"""
 		Return the number of events within this span.
 
-		:return: Number of events.
+		:returns: Number of events.
 		"""
 		return len(self._events)
 
@@ -334,7 +334,7 @@ class Span(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property accessing the absolute time when the span was started.
 
-		:return: The time when the span was entered, otherwise None.
+		:returns: The time when the span was entered, otherwise None.
 		"""
 		return self._beginTime
 
@@ -343,7 +343,7 @@ class Span(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property accessing the absolute time when the span was stopped.
 
-		:return: The time when the span was exited, otherwise None.
+		:returns: The time when the span was exited, otherwise None.
 		"""
 		return self._endTime
 
@@ -354,7 +354,7 @@ class Span(metaclass=ExtendedType, slots=True):
 
 		If the span is not yet stopped, the duration from start to now is returned.
 
-		:return:                  Duration since span was started in seconds.
+		:returns:                  Duration since span was started in seconds.
 		:raises TracingException: When span was never started.
 		"""
 		if self._startTime is None:
@@ -384,7 +384,7 @@ class Span(metaclass=ExtendedType, slots=True):
 
 		A span will be started.
 
-		:return: The span itself.
+		:returns: The span itself.
 		"""
 		global _threadLocalData
 

--- a/pyTooling/Tree/__init__.py
+++ b/pyTooling/Tree/__init__.py
@@ -965,7 +965,7 @@ class Node(Generic[IDType, ValueType, DictKeyType, DictValueType], metaclass=Ext
 		:param nodeMarker:     A string printed before every non-last tree node. Default: ``"├─"``.
 		:param lastNodeMarker: A string printed before every last tree node. Default: ``"└─"``.
 		:param bypassMarker:   A string printed when there are further nodes in the parent level. Default: ``"│ "``.
-		:return:               A rendered tree as multiline string.
+		:returns:               A rendered tree as multiline string.
 		"""
 		emptyMarker = " " * len(bypassMarker)
 

--- a/pyTooling/Tree/__init__.py
+++ b/pyTooling/Tree/__init__.py
@@ -469,7 +469,7 @@ class Node(Generic[IDType, ValueType, DictKeyType, DictValueType], metaclass=Ext
 	@readonly
 	def Level(self) -> int:
 		"""
-		Read-only property to return a node's level in the tree.
+		Read-only property to access a node's level in the tree.
 
 		The level is the distance to the root node.
 
@@ -965,7 +965,7 @@ class Node(Generic[IDType, ValueType, DictKeyType, DictValueType], metaclass=Ext
 		:param nodeMarker:     A string printed before every non-last tree node. Default: ``"├─"``.
 		:param lastNodeMarker: A string printed before every last tree node. Default: ``"└─"``.
 		:param bypassMarker:   A string printed when there are further nodes in the parent level. Default: ``"│ "``.
-		:returns:               A rendered tree as multiline string.
+		:returns:              A rendered tree as multiline string.
 		"""
 		emptyMarker = " " * len(bypassMarker)
 

--- a/pyTooling/Versioning/__init__.py
+++ b/pyTooling/Versioning/__init__.py
@@ -238,7 +238,7 @@ def WordSizeValidator(
 	:param minorBits: Number of bits to encode a positive minor number in a version.
 	:param microBits: Number of bits to encode a positive micro number in a version.
 	:param buildBits: Number of bits to encode a positive build number in a version.
-	:returns:          A validation function for Version instances.
+	:returns:         A validation function for Version instances.
 	"""
 	majorMax = minorMax = microMax = buildMax = -1
 	if bits is not None:
@@ -287,7 +287,7 @@ def MaxValueValidator(
 	:param minorMax: The upper bound for the positive minor number.
 	:param microMax: The upper bound for the positive micro number.
 	:param buildMax: The upper bound for the positive build number.
-	:returns:         A validation function for Version instances.
+	:returns:        A validation function for Version instances.
 	"""
 	if max is not None:
 		majorMax = minorMax = microMax = buildMax = max
@@ -722,7 +722,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		   * ``%b`` - build number
 
 		:param formatSpec: The format specification.
-		:returns:           Formatted version number.
+		:returns:          Formatted version number.
 		"""
 		if formatSpec == "":
 			return self.__str__()
@@ -1689,7 +1689,7 @@ class CalendarVersion(Version):
 		   * ``%u`` - micro number (day)
 
 		:param formatSpec: The format specification.
-		:returns:           Formatted version number.
+		:returns:          Formatted version number.
 		"""
 		if formatSpec == "":
 			return self.__str__()

--- a/pyTooling/Versioning/__init__.py
+++ b/pyTooling/Versioning/__init__.py
@@ -238,7 +238,7 @@ def WordSizeValidator(
 	:param minorBits: Number of bits to encode a positive minor number in a version.
 	:param microBits: Number of bits to encode a positive micro number in a version.
 	:param buildBits: Number of bits to encode a positive build number in a version.
-	:return:          A validation function for Version instances.
+	:returns:          A validation function for Version instances.
 	"""
 	majorMax = minorMax = microMax = buildMax = -1
 	if bits is not None:
@@ -287,7 +287,7 @@ def MaxValueValidator(
 	:param minorMax: The upper bound for the positive minor number.
 	:param microMax: The upper bound for the positive micro number.
 	:param buildMax: The upper bound for the positive build number.
-	:return:         A validation function for Version instances.
+	:returns:         A validation function for Version instances.
 	"""
 	if max is not None:
 		majorMax = minorMax = microMax = buildMax = max
@@ -506,7 +506,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the used parts of this version number.
 
-		:return: A flag enumeration of used version number parts.
+		:returns: A flag enumeration of used version number parts.
 		"""
 		return self._parts
 
@@ -515,7 +515,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the version number's prefix.
 
-		:return: The prefix of the version number.
+		:returns: The prefix of the version number.
 		"""
 		return self._prefix
 
@@ -524,7 +524,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the major number.
 
-		:return: The major number.
+		:returns: The major number.
 		"""
 		return self._major
 
@@ -533,7 +533,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the minor number.
 
-		:return: The minor number.
+		:returns: The minor number.
 		"""
 		return self._minor
 
@@ -542,7 +542,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the micro number.
 
-		:return: The micro number.
+		:returns: The micro number.
 		"""
 		return self._micro
 
@@ -551,7 +551,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the release level.
 
-		:return: The release level.
+		:returns: The release level.
 		"""
 		return self._releaseLevel
 
@@ -560,7 +560,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the release number.
 
-		:return: The release number.
+		:returns: The release number.
 		"""
 		return self._releaseNumber
 
@@ -569,7 +569,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the post number.
 
-		:return: The post number.
+		:returns: The post number.
 		"""
 		return self._post
 
@@ -578,7 +578,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the development number.
 
-		:return: The development number.
+		:returns: The development number.
 		"""
 		return self._dev
 
@@ -587,7 +587,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the build number.
 
-		:return: The build number.
+		:returns: The build number.
 		"""
 		return self._build
 
@@ -596,7 +596,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the version number's postfix.
 
-		:return: The postfix of the version number.
+		:returns: The postfix of the version number.
 		"""
 		return self._postfix
 
@@ -605,7 +605,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the version number's hash.
 
-		:return: The hash.
+		:returns: The hash.
 		"""
 		return self._hash
 
@@ -614,7 +614,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		"""
 		Read-only property to access the version number's flags.
 
-		:return: The flags of the version number.
+		:returns: The flags of the version number.
 		"""
 		return self._flags
 
@@ -722,7 +722,7 @@ class Version(metaclass=ExtendedType, slots=True):
 		   * ``%b`` - build number
 
 		:param formatSpec: The format specification.
-		:return:           Formatted version number.
+		:returns:           Formatted version number.
 		"""
 		if formatSpec == "":
 			return self.__str__()
@@ -1164,7 +1164,7 @@ class SemanticVersion(Version):
 
 		The patch number is identical to the micro number.
 
-		:return: The patch number.
+		:returns: The patch number.
 		"""
 		return self._micro
 
@@ -1521,12 +1521,12 @@ class CalendarVersion(Version):
 
 		return version
 
-	@property
+	@readonly
 	def Year(self) -> int:
 		"""
 		Read-only property to access the year part.
 
-		:return: The year part.
+		:returns: The year part.
 		"""
 		return self._major
 
@@ -1689,7 +1689,7 @@ class CalendarVersion(Version):
 		   * ``%u`` - micro number (day)
 
 		:param formatSpec: The format specification.
-		:return:           Formatted version number.
+		:returns:           Formatted version number.
 		"""
 		if formatSpec == "":
 			return self.__str__()
@@ -1770,12 +1770,12 @@ class YearMonthVersion(CalendarVersion):
 		"""
 		super().__init__(year, month, 0, build, flags, prefix, postfix)
 
-	@property
+	@readonly
 	def Month(self) -> int:
 		"""
 		Read-only property to access the month part.
 
-		:return: The month part.
+		:returns: The month part.
 		"""
 		return self._minor
 
@@ -1820,12 +1820,12 @@ class YearWeekVersion(CalendarVersion):
 		"""
 		super().__init__(year, week, 0, build, flags, prefix, postfix)
 
-	@property
+	@readonly
 	def Week(self) -> int:
 		"""
 		Read-only property to access the week part.
 
-		:return: The week part.
+		:returns: The week part.
 		"""
 		return self._minor
 
@@ -1870,12 +1870,12 @@ class YearReleaseVersion(CalendarVersion):
 		"""
 		super().__init__(year, release, 0, build, flags, prefix, postfix)
 
-	@property
+	@readonly
 	def Release(self) -> int:
 		"""
 		Read-only property to access the release number.
 
-		:return: The release number.
+		:returns: The release number.
 		"""
 		return self._minor
 
@@ -1920,21 +1920,21 @@ class YearMonthDayVersion(CalendarVersion):
 		"""
 		super().__init__(year, month, day, build, flags, prefix, postfix)
 
-	@property
+	@readonly
 	def Month(self) -> int:
 		"""
 		Read-only property to access the month part.
 
-		:return: The month part.
+		:returns: The month part.
 		"""
 		return self._minor
 
-	@property
+	@readonly
 	def Day(self) -> int:
 		"""
 		Read-only property to access the day part.
 
-		:return: The day part.
+		:returns: The day part.
 		"""
 		return self._micro
 
@@ -2011,7 +2011,7 @@ class VersionRange(Generic[V], metaclass=ExtendedType, slots=True):
 		"""
 		Property to access the range's lower bound.
 
-		:return: Lower bound of the version range.
+		:returns: Lower bound of the version range.
 		"""
 		return self._lowerBound
 
@@ -2029,7 +2029,7 @@ class VersionRange(Generic[V], metaclass=ExtendedType, slots=True):
 		"""
 		Property to access the range's upper bound.
 
-		:return: Upper bound of the version range.
+		:returns: Upper bound of the version range.
 		"""
 		return self._upperBound
 
@@ -2047,7 +2047,7 @@ class VersionRange(Generic[V], metaclass=ExtendedType, slots=True):
 		"""
 		Property to access the range's bound handling strategy.
 
-		:return: The range's bound handling strategy.
+		:returns: The range's bound handling strategy.
 		"""
 		return self._boundHandling
 

--- a/pyTooling/Warning/__init__.py
+++ b/pyTooling/Warning/__init__.py
@@ -74,7 +74,7 @@ class CriticalWarning(BaseException):
 	@readonly
 	def Notes(self) -> Tuple[str, ...]:
 		"""
-		Read-only property to access warning's attached notes.
+		Read-only property to return warning's attached notes.
 
 		:returns: Attached notes.
 		"""
@@ -103,7 +103,7 @@ class Warning(BaseException):
 	@readonly
 	def Notes(self) -> Tuple[str, ...]:
 		"""
-		Read-only property to access warning's attached notes.
+		Read-only property to return warning's attached notes.
 
 		:returns: Attached notes.
 		"""
@@ -545,7 +545,7 @@ class ThreadSupervisor:
 	@readonly
 	def Warnings(self) -> List[AnyWarning]:
 		"""
-		Read-only property to access all warnings collected from supervised threads (:attr:`_warnings`).
+		Read-only property to return all warnings collected from supervised threads (:attr:`_warnings`).
 
 		:returns: List of collected warnings, without their thread names.
 		"""

--- a/pyTooling/Warning/__init__.py
+++ b/pyTooling/Warning/__init__.py
@@ -444,6 +444,11 @@ class SupervisedThreadException(ExceptionBase):
 
 	@readonly
 	def ThreadName(self) -> str:
+		"""
+		Read-only property to access the name of the thread that raised the exception (:attr:`_threadName`).
+
+		:returns: Name of the thread.
+		"""
 		return self._threadName
 
 
@@ -517,18 +522,33 @@ class ThreadSupervisor:
 		self._exceptions = []
 		self._warnings =   []
 
-	@property
+	@readonly
 	def HasWarning(self) -> bool:
+		"""
+		Check if at least one warning was collected from a supervised thread.
+
+		:returns: ``True``, if at least one warning was collected.
+		"""
 		with self._lock:
 			return len(self._warnings) > 0
 
-	@property
+	@readonly
 	def HasExceptions(self) -> bool:
+		"""
+		Check if at least one exception was collected from a supervised thread.
+
+		:returns: ``True``, if at least one exception was collected.
+		"""
 		with self._lock:
 			return len(self._exceptions) > 0
 
-	@property
+	@readonly
 	def Warnings(self) -> List[AnyWarning]:
+		"""
+		Read-only property to access all warnings collected from supervised threads (:attr:`_warnings`).
+
+		:returns: List of collected warnings, without their thread names.
+		"""
 		with self._lock:
 			return [warning for _, warning in self._warnings]
 

--- a/tests/unit/MetaClasses/SlottedType.py
+++ b/tests/unit/MetaClasses/SlottedType.py
@@ -37,7 +37,7 @@ from unittest              import TestCase
 from pytest                import mark
 
 from pyTooling.MetaClasses import ExtendedType, BaseClassIsNotAMixinError, BaseClassWithNonEmptySlotsError, BaseClassWithoutSlotsError
-from pyTooling.MetaClasses import DuplicateFieldInSlotsError, ShadowedSlotWarning, UnannotatedFieldWarning
+from pyTooling.MetaClasses import DuplicateFieldInSlotsError, UnannotatedFieldWarning
 from pyTooling.Decorators  import readonly
 from pyTooling.Warning     import WarningCollector
 from pyTooling.Common      import getsizeof
@@ -1133,37 +1133,20 @@ class SlotShadowedByClassMember(TestCase):
 	"""
 
 	def test_ShadowedInheritedSlot(self) -> None:
-		"""
-		An inherited slot isn't in the derived class' ``__slots__``, so Python accepts the class body and only an
-		assignment on an instance fails. That's harmless if the field is never assigned, so it's a warning.
-		"""
-		warnings = []
-		with WarningCollector(handler=lambda warning: warnings.append(warning) or False):
-			class Base(metaclass=ExtendedType, slots=True):
-				_data_0: int
+		class Base(metaclass=ExtendedType, slots=True):
+			_data_0: int
 
-				def __init__(self) -> None:
-					self._data_0 = 1
+			def __init__(self) -> None:
+				self._data_0 = 1
 
+		with self.assertRaises(DuplicateFieldInSlotsError) as context:
 			class Derived(Base):
 				_data_0 = 5
 
-		shadowed = [w for w in warnings if isinstance(w, ShadowedSlotWarning)]
-
-		self.assertEqual(1, len(shadowed))
-		self.assertIn("_data_0", str(shadowed[0]))
-		self.assertIn("Slot '_data_0' is declared in base-class", shadowed[0].__notes__[0])
-
-		# Reading works, assigning doesn't.
-		self.assertEqual(5, Derived._data_0)
-		with self.assertRaises(AttributeError):
-			Derived().__setattr__("_data_0", 6)
+		self.assertIn("_data_0", str(context.exception))
+		self.assertIn("Slot '_data_0' is declared in base-class", context.exception.__notes__[0])
 
 	def test_ShadowedMixinSlot(self) -> None:
-		"""
-		A mixin's slot is materialized in this class' own ``__slots__``, which Python rejects outright, so this stays an
-		exception.
-		"""
 		class Mixin(metaclass=ExtendedType, mixin=True):
 			_data_M1: int
 
@@ -1175,6 +1158,7 @@ class SlotShadowedByClassMember(TestCase):
 				_data_M1 = 5
 
 		self.assertIn("Slot '_data_M1' is contributed by a mixin-class", context.exception.__notes__[0])
+		self.assertIn("Python doesn't allow a name to be listed in '__slots__'", context.exception.__notes__[1])
 
 	def test_ClassVariableIsNotShadowing(self) -> None:
 		"""Annotating the assignment as a ClassVar is the documented way out."""

--- a/tests/unit/MetaClasses/SlottedType.py
+++ b/tests/unit/MetaClasses/SlottedType.py
@@ -37,7 +37,7 @@ from unittest              import TestCase
 from pytest                import mark
 
 from pyTooling.MetaClasses import ExtendedType, BaseClassIsNotAMixinError, BaseClassWithNonEmptySlotsError, BaseClassWithoutSlotsError
-from pyTooling.MetaClasses import DuplicateFieldInSlotsError, UnannotatedFieldWarning
+from pyTooling.MetaClasses import DuplicateFieldInSlotsError, ShadowedSlotWarning, UnannotatedFieldWarning
 from pyTooling.Decorators  import readonly
 from pyTooling.Warning     import WarningCollector
 from pyTooling.Common      import getsizeof
@@ -1133,20 +1133,37 @@ class SlotShadowedByClassMember(TestCase):
 	"""
 
 	def test_ShadowedInheritedSlot(self) -> None:
-		class Base(metaclass=ExtendedType, slots=True):
-			_data_0: int
+		"""
+		An inherited slot isn't in the derived class' ``__slots__``, so Python accepts the class body and only an
+		assignment on an instance fails. That's harmless if the field is never assigned, so it's a warning.
+		"""
+		warnings = []
+		with WarningCollector(handler=lambda warning: warnings.append(warning) or False):
+			class Base(metaclass=ExtendedType, slots=True):
+				_data_0: int
 
-			def __init__(self) -> None:
-				self._data_0 = 1
+				def __init__(self) -> None:
+					self._data_0 = 1
 
-		with self.assertRaises(DuplicateFieldInSlotsError) as context:
 			class Derived(Base):
 				_data_0 = 5
 
-		self.assertIn("_data_0", str(context.exception))
-		self.assertIn("Slot '_data_0' is declared in base-class", context.exception.__notes__[0])
+		shadowed = [w for w in warnings if isinstance(w, ShadowedSlotWarning)]
+
+		self.assertEqual(1, len(shadowed))
+		self.assertIn("_data_0", str(shadowed[0]))
+		self.assertIn("Slot '_data_0' is declared in base-class", shadowed[0].__notes__[0])
+
+		# Reading works, assigning doesn't.
+		self.assertEqual(5, Derived._data_0)
+		with self.assertRaises(AttributeError):
+			Derived().__setattr__("_data_0", 6)
 
 	def test_ShadowedMixinSlot(self) -> None:
+		"""
+		A mixin's slot is materialized in this class' own ``__slots__``, which Python rejects outright, so this stays an
+		exception.
+		"""
 		class Mixin(metaclass=ExtendedType, mixin=True):
 			_data_M1: int
 
@@ -1157,7 +1174,7 @@ class SlotShadowedByClassMember(TestCase):
 			class Final(Primary, Mixin, metaclass=ExtendedType, slots=True):
 				_data_M1 = 5
 
-		self.assertIn("Slot '_data_M1' is contributed by a mixin-class.", context.exception.__notes__[0])
+		self.assertIn("Slot '_data_M1' is contributed by a mixin-class", context.exception.__notes__[0])
 
 	def test_ClassVariableIsNotShadowing(self) -> None:
 		"""Annotating the assignment as a ClassVar is the documented way out."""


### PR DESCRIPTION

# Changes

* `pyTooling.Versioning`:
  * `CalendarVersion.Year`, `YearMonthVersion.Month`, `YearWeekVersion.Week`, `YearReleaseVersion.Release`, `YearMonthDayVersion.Month` and `YearMonthDayVersion.Day` are marked `@readonly`. They had no setter, while `Version.Major`, `.Minor`, `.Micro` and `.Prefix` in the same file already used `@readonly`.
* `pyTooling.Attributes`:
  * `Attribute.Scope` is marked `@readonly`.
* `pyTooling.Warning`:
  * `ThreadSupervisor.HasWarning`, `.HasExceptions` and `.Warnings` are marked `@readonly`.

# Bug Fixes

* `pyTooling.Filesystem`:
  * `Element.Path` raised `NotImplemented(...)`. `NotImplemented` is a singleton, not an exception class, so calling it raised `TypeError: 'NotImplementedType' object is not callable` instead of the intended `NotImplementedError`.

# Documentation

* All 337 properties carry a doc-string with a `:returns:` field.
  * 80 had no doc-string at all — `Filesystem` 31, `Graph.GraphML` 22, `Dependency` 17, plus a handful elsewhere.
  * 25 more had a one-line doc-string and no `:returns:` field.
* Doc-strings follow the pattern already used in `pyTooling.Graph`:
  ```
  Read-only property to access <what> (:attr:`_field`).

  :returns: <what>.
  ```
  Boolean queries use `Check if ...` with `:returns: ``True``, if ...`, matching the wording agreed for pyVHDLModel.
* Normalized the field name to `:returns:` throughout the package (141 sites). Both spellings are valid Sphinx aliases, but `CLAUDE.md` picks the plural and the existing split was 519 to 141 in its favour.
* `Root.TotalHardLinkCount3` counts files that are **not** hardlinked, despite its name. It's documented with an `.. attention::` rather than renamed, since the name is public API. `TotalHardLinkCount`, `TotalHardLinkCount2`, `Size2` and `Size3` differ subtly from each other and now each state their own counting rule.

